### PR TITLE
Simplify eval_mesh.py, make vtk optional

### DIFF
--- a/src/eval_mesh.py
+++ b/src/eval_mesh.py
@@ -11,29 +11,28 @@ def main():
     points, cells, cell_types, _ = read_mesh(args.in_meshname)
     points = np.array(points)
     values = user_func(points, args.f_str)
-    out_meshname = args.out_meshname if args.out_meshname else args.in_meshname[:-4] + ".txt"
+    out_meshname = args.out_meshname if args.out_meshname else args.in_meshname
     write_mesh(out_meshname, points, cells, cell_types, values)
 
 def user_func(points, f_str = None):
+    import math
+    import numpy as np
     if not f_str:
         f_str = "y = np.zeros(len(x))"
-    x = np.array(points)
-    loc_dict = {"x": x}
-    exec(f_str, globals(), loc_dict)
-    y = loc_dict["y"]
-    if y is None:
-        raise Exception("Invalid function. y was not assigned a value")
-    if len(y) != len(x):
-        raise Exception("Invalid function. y has wrong shape.")
-    return y
+    points = np.array(points)
+    vals = np.zeros(points.shape[0])
+    for i, (x, y, z) in enumerate(points):
+        loc_dict = {"x": x, "y": y, "z": z, "math": math, "np": np}
+        vals[i] = eval(f_str, globals(), loc_dict)
+    return vals
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Evaluate a function on a given mesh")
     parser.add_argument("in_meshname", metavar="inputmesh", help="The mesh used as input")
     parser.add_argument("--func", "-f", dest="f_str", 
             help="""The function to evalutate on the mesh. 
-            Points are given in the form \"x = [[x1,y1,z1],[x2,y2,z2],...]\" as a numpy array. 
-            Output must be written to \"y\". Default is the 0 function.""")
+            Points are given in the form \"(x, y, z)\". An example for a function would be
+            \"math.sin(x) + math.exp(z)\". Default is the 0 function.""")
     parser.add_argument("--out", "-o", dest="out_meshname", help="""The output meshname. 
             Default is the same as for the input mesh""")
     parser.add_argument("--log", "-l", dest="logging", default="INFO", 

--- a/src/mesh_io.py
+++ b/src/mesh_io.py
@@ -4,7 +4,7 @@ Mesh I/O utility script. One can read meshes from .vtk, .txt, .vtu, .vtp,... fil
 """
 
 import os
-import vtk
+import logging
 
 
 def read_mesh(filename):
@@ -28,6 +28,7 @@ def write_mesh(filename, points, cells = None, cell_types = None, values = None)
 
     
 def read_vtk(filename):
+    import vtk
     vtkmesh = read_dataset(filename)
     points = []
     cells = []
@@ -49,6 +50,7 @@ def read_vtk(filename):
 
 
 def read_dataset(filename):
+    import vtk
     extension = os.path.splitext(filename)[1]
     if (extension == ".vtk"): # VTK Legacy format
         reader = vtk.vtkDataSetReader()
@@ -85,6 +87,7 @@ def read_txt(filename):
 
 
 def write_vtk(filename, points, cells = None, cell_types = None, pointdata = None):
+    import vtk
     data = vtk.vtkUnstructuredGrid() # is also vtkDataSet
     scalars = vtk.vtkDoubleArray()
     vtkpoints = vtk.vtkPoints()
@@ -115,6 +118,7 @@ def write_vtk(filename, points, cells = None, cell_types = None, pointdata = Non
 
     
 def write_dataset(filename, dataset):
+    import vtk
     extension = os.path.splitext(filename)[1]
     if (extension == ".vtk"): # VTK Legacy format
         writer = vtk.vtkUnstructuredGridWriter()


### PR DESCRIPTION
`eval_mesh.py` was hard to understand. Now it's easy. Also vtk is now only required if it is used.