### PR TITLE
Multiple timesteps

### DIFF
--- a/contrib/demo.sh
+++ b/contrib/demo.sh
@@ -1,12 +1,14 @@
-#!/usr/bin/zsh
+#!/usr/bin/bash
 set -e
 set -x
 #cp ../eval_mesh.py ../join_mesh.py ../read_mesh.py ../preciceDist ../precice.xml ../libmetisAPI.so .
 test -f rbc.vtk || wget "https://people.sc.fsu.edu/~jburkardt/data/vtk/rbc_001.vtk" -O rbc.vtk
 test -f bunny.vtk || wget "https://www.ece.lsu.edu/xinli/Meshing/Data/bunny.vtk" -O bunny.vtk
-./eval_mesh.py bunny.vtk -o colored.vtk -f "y = x[:,1]"
+./eval_mesh.py bunny.vtk -o colored.vtk "x + y"
 ./partition_mesh.py colored.vtk -n 2
 ./partition_mesh.py rbc.vtk -n 2
-mpirun -n 2 ./preciceMap -p A --meshFile colored&
-mpirun -n 2 ./preciceMap -p B --meshFile rbc --output mapped
+mv -f colored colored.dt1
+mv -f rbc rbc.dt1
+mpirun -n 2 ./preciceMap -p A --mesh colored&
+mpirun -n 2 ./preciceMap -p B --mesh rbc --output mapped
 ./join_mesh.py mapped -o result.vtk

--- a/contrib/timestep-demo/clean.sh
+++ b/contrib/timestep-demo/clean.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+rm -rf colored* rbc.dt1* bunny.vtk vtkA vtkB precice-A-events.json precice-B-events.json filtered.log mapped debug.log

--- a/contrib/timestep-demo/timesteps-precice.xml
+++ b/contrib/timestep-demo/timesteps-precice.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+  <log enabled="true">
+    <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true" />
+    <sink type="file" output="filtered.log"  filter= "(%Severity% > debug) or (%Severity% >= trace and %Module% contains SolverInterfaceImpl)" enabled="true" />
+    <sink type="file" output="debug.log" filter="" enabled="true"/>
+  </log>
+  
+  <solver-interface dimensions="3">
+    
+    <!-- Data fields that are exchanged between the solvers -->
+    <data:scalar name="Data" />
+
+    <!-- A common mesh that uses these data fields -->
+    <mesh name="MeshA" flip-normals="no">
+      <use-data name="Data" />
+    </mesh>
+
+    <mesh name="MeshB" flip-normals="no">
+      <use-data name="Data" />
+    </mesh>
+    
+    <m2n:sockets from="A" to="B" network="lo" exchange-directory=".."  distribution-type="point-to-point" />
+
+    <participant name="A">
+      <use-mesh name="MeshA" provide="yes" />
+
+      <write-data name="Data" mesh="MeshA" />
+      <!-- <mapping:nearest-neighbor constraint="conservative" direction="write" from="MeshA" to="MeshB" /> -->
+      <!-- <mapping:petrbf-gaussian shape-parameter="2" solver-rtol="1e-9" constraint="conservative" direction="write" from="MeshA" to="MeshB" x-dead="false" y-dead="true" z-dead="false" /> -->
+      <!-- <mapping:rbf-gaussian shape-parameter="10" constraint="conservative" direction="write" from="MeshA" to="MeshB" x-dead="false" y-dead="true" z-dead="false" /> -->
+
+      <export:vtk timestep-interval="1" directory="vtkA/" normals="0"/>
+      <master:mpi-single />
+    </participant>
+    
+    <participant name="B">
+      <use-mesh name="MeshA" provide="no" from="A" />
+      <use-mesh name="MeshB" provide="yes" />
+      <read-data name="Data" mesh="MeshB" />
+      <mapping:nearest-neighbor constraint="consistent" direction="read" from="MeshA" to="MeshB" />
+          <!-- <mapping:rbf-gaussian shape-parameter="4" constraint="consistent" direction="read" from="MeshA" to="MeshB" x-dead="false" y-dead="false" z-dead="false" /> -->
+          <!-- <mapping:petrbf-gaussian shape-parameter="5600" solver-rtol="1e-9" constraint="consistent" direction="read" from="MeshA" to="MeshB" x-dead="true" y-dead="false" z-dead="false" polynomial="separate" preallocation="tree"/> -->
+      <!-- <mapping:petrbf-volume-splines solver-rtol="1e-9" constraint="consistent" direction="read" from="MeshA" to="MeshB" x-dead="false" y-dead="false" z-dead="false" /> -->
+      <export:vtk timestep-interval="1" directory="vtkB/" normals="0"/>
+      <master:mpi-single />
+    </participant>
+
+    
+    <coupling-scheme:parallel-explicit>
+      <participants first="A" second="B" />
+      <max-time value="20.0" />
+      <timestep-length value="1" />
+      <exchange data="Data" mesh="MeshA" from="A" to="B" />
+      <!-- <exchange data="Data" mesh="MeshB" from="A" to="B" /> -->
+    </coupling-scheme:parallel-explicit>
+    
+  </solver-interface>
+  
+</precice-configuration>

--- a/contrib/timestep-demo/timesteps.py
+++ b/contrib/timestep-demo/timesteps.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import subprocess
+import os
+if (os.environ.get("ASTEDIR")):
+    astedir = os.environ["ASTEDIR"]
+else:
+    astedir = "." # Set this to the build directory of aste
+if (not astedir[-1] == "/"):
+    astedir = astedir + "/"
+
+def run(cmd):
+    print("+" + cmd)
+    subprocess.run(("bash", "-c", cmd))
+
+# Get bunny and red blood cell
+if not os.path.isfile("rbc.dt1.vtk"):
+    run("wget https://people.sc.fsu.edu/~jburkardt/data/vtk/rbc_001.vtk -O rbc.dt1.vtk")
+if not os.path.isfile("bunny.vtk"):
+    run("wget https://www.ece.lsu.edu/xinli/Meshing/Data/bunny.vtk -O bunny.vtk")
+# Generate 20 timesteps of bunny.vtk
+files = ["colored.dt" + str(i) + ".vtk" for i in range(1, 21)]
+for t in range(len(files)):
+    if not os.path.isfile(files[t]):
+        run(astedir + "eval_mesh.py bunny.vtk -o " + files[t] + " " + str(t + 1))
+if not all([os.path.isdir("colored.dt"  + str(i)) for i in range(1, 21)]):
+    run(astedir + "partition_mesh.py -n 2 " + " ".join(files))
+# Partition output mesh as well
+run(astedir + "partition_mesh.py -n 2 rbc.dt1.vtk ")
+# Run preCICE. Note that the meshes are named colored.dt1, colored.dt2, ...
+if not os.path.isdir("vtkA"):
+    os.mkdir("vtkA")
+if not os.path.isdir("vtkB"):
+    os.mkdir("vtkB")
+run("mpirun -n 2 " + astedir + "preciceMap -c timesteps-precice.xml -p A --mesh colored&")
+run("mpirun -n 2 " + astedir + "preciceMap -c timesteps-precice.xml -p B --mesh rbc --output mapped")
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Reads a partitioned mesh from a directory like `dirname/0, 1, ...` and saves it 
 This is a small C++ wrapper around METIS. It is only required if `partition_mesh.py` should use a topological algorithm. 
 
 ### preciceMap
-This is a C++ application, which does the coupling through precice. It expects a mesh in the format given by `partition_mesh.py`.
+This is a C++ application, which does the coupling through precice. It expects a mesh in the format given by `partition_mesh.py`. currently, only explict coupling is supported. When using multiple timesteps, make sure to provide a mesh (with data) for each timestep.
 
 ## Dependencies
 
@@ -63,4 +63,6 @@ and execute cmake like `cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
 
 
 ## Demo
-A demonstration of aste can be run with `./demo.sh`. A bunny-shaped mesh is mapped onto a red blood cell. The result can be seen in `result.vtk`. 
+A simple demonstration of aste can be run with `./demo.sh`. A bunny-shaped mesh is mapped onto a red blood cell. The result can be seen in `result.vtk`. 
+## Demo with multiple timesteps
+A similar demo with multiple timesteps can be run with `./timesteps.py` inside `contrib/timestep-demo`. Make sure to set `astedir` inside `timesteps.py` to the correct value (By using the environment variable `ASTEDIR`). For details look into the `timesteps.py` and the corresponding `timesteps-precice.xml` file.

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -18,7 +18,7 @@ OptionMap getOptions(int argc, char *argv[])
     ("participant,p", po::value<std::string>()->required(), "Participant Name")
     ("runName", po::value<std::string>()->default_value(""), "Name of the run")
     ("printMesh", po::bool_switch(), "Prints the full mesh")
-    ("mesh", po::value<string>()->required(), "Mesh directory")
+    ("mesh", po::value<string>()->required(), "Mesh directory. For each timestep i there will be .dti (e.g. .dt4) appended to the directory name")
     ("output", po::value<string>()->default_value("output"));
   
   po::variables_map vm;        

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <istream>
+#include <fstream>
 #include <string>
 #include <boost/filesystem.hpp>
 #include <mpi.h>
@@ -12,11 +14,34 @@ namespace fs = boost::filesystem;
 int numMeshParts(std::string meshname)
 {
     if (not fs::is_directory(meshname))
-        throw std::runtime_error("Invalid mesh name: directory not found.");
+        throw std::runtime_error("Invalid mesh name: Directory not found. Directory Name: " + meshname);
     int i = 0;
     while (fs::exists(meshname + "/" + std::to_string(i)))
         i++;
     return i;
+}
+
+struct Mesh {
+    std::vector<std::array<double, 3>> positions;
+    std::vector<double> data;
+};
+
+Mesh readMesh(std::istream& stream, bool read_data = true)
+{
+    Mesh mesh;
+    double x, y, z, val;
+    std::string line;
+    while (std::getline(stream, line)){
+        std::istringstream iss(line);
+        iss >> x >> y >> z >> val;
+        std::array<double, 3> vertexPos{x, y, z};
+        mesh.positions.push_back(vertexPos);
+        if (read_data) //val is ignored on B.
+            mesh.data.push_back(val);
+    }
+    if (!read_data)
+        mesh.data = std::vector<double>(mesh.positions.size(), 0);
+    return mesh;
 }
 
 int main(int argc, char* argv[])
@@ -31,7 +56,7 @@ int main(int argc, char* argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &MPIrank);
     MPI_Comm_size(MPI_COMM_WORLD, &MPIsize);
 
-    auto numParts = numMeshParts(meshname);
+    auto numParts = numMeshParts(meshname + ".dt1");
     if (numParts < MPIsize)
         throw std::runtime_error("Mesh is too small for communicator, MeshSize="  + std::to_string(numParts)
                                  + ", Comm_size=" + std::to_string(MPIsize));
@@ -42,47 +67,41 @@ int main(int argc, char* argv[])
     int meshID = interface.getMeshID( (participant == "A") ? "MeshA" : "MeshB" ); // participant = A => MeshID = MeshA
     int dataID = interface.getDataID("Data", meshID);
     std::vector<int> vertexIDs;
-    std::vector<double> data;
-    std::vector<std::array<double, 3>> positions;
-    int i = 0;
-    auto filename = meshname + "/" + std::to_string(MPIrank);
+    auto filename = meshname + ".dt1/" + std::to_string(MPIrank);
     std::ifstream infile(filename);
-    double x, y, z, val;
-    std::string line;
-    while (std::getline(infile, line)){
-        std::istringstream iss(line);
-        iss >> x >> y >> z >> val;
-        std::array<double, 3> vertexPos{x, y, z};
-        vertexIDs.push_back(interface.setMeshVertex(meshID, vertexPos.data()));
-        positions.push_back(vertexPos);
-        if (participant == "A") //val is ignored on B.
-            data.push_back(val);
-        i++;
-    }
+    auto mesh = readMesh(infile, participant == "A");
     infile.close();
-    if (participant == "B")
-        data = std::vector<double>(vertexIDs.size(), 0);
-
+    for (const auto& pos : mesh.positions)
+        vertexIDs.push_back(interface.setMeshVertex(meshID, pos.data()));
     std::cout << "========= Rank " << MPIrank << " read in mesh of size " << vertexIDs.size() << std::endl;
     
     interface.initialize();
 
     if (interface.isActionRequired(precice::constants::actionWriteInitialData())) {
         std::cout << "Write initial data for participant " << participant << std::endl;
-        interface.writeBlockScalarData(dataID, data.size(), vertexIDs.data(), data.data());
+        interface.writeBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
         interface.fulfilledAction(precice::constants::actionWriteInitialData());
     }
     interface.initializeData();
 
+    int round = 1;
     while (interface.isCouplingOngoing()) {
-        if (participant == "A" and not data.empty()) {
-            interface.writeBlockScalarData(dataID, data.size(), vertexIDs.data(), data.data());
+        if (participant == "A" and not mesh.data.empty()) {
+            auto filename = meshname + ".dt" + std::to_string(round)
+                + "/" + std::to_string(MPIrank);
+            if (not boost::filesystem::exists(filename))
+                throw std::runtime_error("File does not exist: " + filename);
+            std::ifstream infile(filename);
+            auto roundmesh = readMesh(infile, participant == "A");
+            infile.close();
+            interface.writeBlockScalarData(dataID, roundmesh.data.size(), vertexIDs.data(), roundmesh.data.data());
         }
         interface.advance(1);
 
         if (participant == "B") {
-            interface.readBlockScalarData(dataID, data.size(), vertexIDs.data(), data.data());
+            interface.readBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
         }
+        round++;
     }
 
     interface.finalize();
@@ -99,7 +118,9 @@ int main(int argc, char* argv[])
         std::cout << "========= Write to " << outdir << std::endl;
         std::ofstream ostream((outdir / std::to_string(MPIrank)).string(), std::ios::trunc);
         ostream.precision(9);
-        for (size_t i = 0; i < data.size(); i++) {
+        const auto& positions = mesh.positions;
+        const auto& data = mesh.data;
+        for (size_t i = 0; i < mesh.positions.size(); i++) {
             ostream << positions[i][0] << " " << positions[i][1] << " " << positions[i][2] << " " << data[i] << std::endl;
         }
         ostream.close();


### PR DESCRIPTION
Enable multiple timesteps with aste. Major changes:

- Meshes are given in the format `--mesh example` to `preciceMap`, which then searches for `example.dt1`, `example.dt2`,...
- `partition_mesh` now works on multiple meshes as well. This is done by using the first mesh for determining a partition and applying it to every mesh given.
- `partition_mesh` can receive a vtk tag with the `--tag` option. This enables easy extraction of data read from vtk exports of preCICE.
- `demo.sh` was broken (is fixed now)