### PR TITLE
VTK Migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ find_package(precice REQUIRED CONFIG)
 
 find_package(Boost 1.65.1 REQUIRED COMPONENTS system program_options filesystem)
 
+find_package(VTK REQUIRED)
+if (NOT VTK_FOUND)
+  message("VTK not found")
+  return ()
+endif()
+message (STATUS "VTK_VERSION: ${VTK_VERSION}")
+include(${VTK_USE_FILE})
+
 find_package(METIS)
 if (METIS_FOUND)
     add_library(metisAPI SHARED src/metisAPI.cpp)
@@ -43,6 +51,7 @@ target_link_libraries(preciceMap
   Boost::program_options
   Boost::system
   MPI::MPI_CXX
+  ${VTK_LIBRARIES}
 )
 
 if(ASTE_SET_MESH_BLOCK)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -16,6 +16,7 @@ OptionMap getOptions(int argc, char *argv[])
     ("precice-config,c", po::value<std::string>()->default_value("precice.xml"), "preCICE configuratio file")
     ("participant,p", po::value<std::string>()->required(), "Participant Name")
     ("runName", po::value<std::string>()->default_value(""), "Name of the run")
+    ("data", po::value<std::string>()->required(), "Name of Data Array to be Mapped")
     ("mesh", po::value<string>()->required(), "Mesh directory. For each timestep i there will be .dti (e.g. .dt4) appended to the directory name")
     ("output", po::value<string>()->default_value("output"), "Output file name.")
     ("verbose,v", po::bool_switch(), "Enable verbose output") // not explicitely used, handled by easylogging

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,45 +1,51 @@
+#include "common.hpp"
+#include "easylogging++.h"
+#include <boost/program_options.hpp>
 #include <iostream>
 #include <mpi.h>
-#include <boost/program_options.hpp>
-#include "easylogging++.h"
-#include "common.hpp"
 
 using namespace std;
 
-OptionMap getOptions(int argc, char *argv[])
-{
+OptionMap getOptions(int argc, char *argv[]) {
   namespace po = boost::program_options;
-  using std::cout; using std::endl;
+  using std::cout;
+  using std::endl;
   po::options_description desc("ASTE: Artificial solver emulation tool");
-  desc.add_options()
-    ("help,h", "produce help")
-    ("precice-config,c", po::value<std::string>()->default_value("precice.xml"), "preCICE configuratio file")
-    ("participant,p", po::value<std::string>()->required(), "Participant Name")
-    ("runName", po::value<std::string>()->default_value(""), "Name of the run")
-    ("data", po::value<std::string>()->required(), "Name of Data Array to be Mapped")
-    ("mesh", po::value<string>()->required(), "Mesh directory. For each timestep i there will be .dti (e.g. .dt4) appended to the directory name")
-    ("output", po::value<string>()->default_value("output"), "Output file name.")
-    ("verbose,v", po::bool_switch(), "Enable verbose output") // not explicitely used, handled by easylogging
-;
-  
-  po::variables_map vm;        
+  desc.add_options()("help,h", "produce help")(
+      "precice-config,c",
+      po::value<std::string>()->default_value("precice.xml"),
+      "preCICE configuratio file")("participant,p",
+                                   po::value<std::string>()->required(),
+                                   "Participant Name")(
+      "runName", po::value<std::string>()->default_value(""),
+      "Name of the run")("data", po::value<std::string>()->required(),
+                         "Name of Data Array to be Mapped")(
+      "mesh", po::value<string>()->required(),
+      "Mesh directory. For each timestep i there will be .dti (e.g. .dt4) "
+      "appended to the directory name")(
+      "output", po::value<string>()->default_value("output"),
+      "Output file name.")(
+      "verbose,v", po::bool_switch(),
+      "Enable verbose output") // not explicitely used, handled by easylogging
+      ;
+
+  po::variables_map vm;
 
   try {
     po::store(parse_command_line(argc, argv, desc), vm);
-    
+
     if (vm.count("help")) {
       std::cout << desc << std::endl;
       std::exit(-1);
     }
-    if (vm["participant"].as<string>() != "A" && vm["participant"].as<string>() != "B")
-        throw runtime_error("Invalid participant, must be either 'A' or 'B'");
+    if (vm["participant"].as<string>() != "A" &&
+        vm["participant"].as<string>() != "B")
+      throw runtime_error("Invalid participant, must be either 'A' or 'B'");
     po::notify(vm);
-  }
-  catch(const std::exception& e) {
+  } catch (const std::exception &e) {
     LOG(ERROR) << "ERROR: " << e.what() << "\n";
     LOG(ERROR) << desc << std::endl;
     std::exit(-1);
   }
-  return vm;  
+  return vm;
 }
-

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -90,32 +90,9 @@ void readMainFile(Mesh &mesh, const std::string &filename,
 
 // Reads the connectivity file containing the triangle and edge information
 void readConnFile(Mesh &mesh, const std::string &filename) {
-  if (!fs::is_regular_file(filename)) {
-    throw std::invalid_argument{"The mesh connectivity file does not exist: " +
-                                filename};
-  }
-  std::ifstream connFile{filename};
-  std::string line;
-  while (std::getline(connFile, line)) {
-    std::vector<std::string> parts;
-    boost::split(parts, line, [](char c) { return c == ' '; });
-    std::vector<size_t> indices(parts.size());
-    std::transform(parts.begin(), parts.end(), indices.begin(),
-                   [](const std::string &s) -> size_t { return std::stol(s); });
-
-    if (indices.size() == 3) {
-      std::array<size_t, 3> elem{indices[0], indices[1], indices[2]};
-      mesh.triangles.push_back(elem);
-    } else if (indices.size() == 2) {
-      std::array<size_t, 2> elem{indices[0], indices[1]};
-      mesh.edges.push_back(elem);
-    } else {
-      throw std::runtime_error{
-          std::string{"Invalid entry in connectivitiy file \""}
-              .append(line)
-              .append("\"")};
-    }
-  }
+  /*
+  This function will be removed/changed in next PR
+  */
 }
 } // namespace
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -84,8 +84,7 @@ void readMainFile(Mesh &mesh, const std::string &filename,
   } else { // There is no data in mesh file fill with zeros.
     std::clog << "There is no data found in the mesh file it will be replaced "
                  "by dummy data.\n";
-    mesh.data.resize(NumPoints);
-    std::fill(mesh.data.begin(), mesh.data.end(), 0.0);
+    mesh.data.resize(NumPoints, 0.0);
   }
 }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -68,7 +68,7 @@ void readMainFile(Mesh &mesh, const std::string &filename,
     int NumComp = ArrayData->GetNumberOfComponents();
     switch (NumComp) {
     case 1: // Scalar Data
-     
+
       for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++) {
         const double scalar = ArrayData->GetTuple1(tupleIdx);
         mesh.data.push_back(scalar);
@@ -82,7 +82,9 @@ void readMainFile(Mesh &mesh, const std::string &filename,
       }
       break;
     }
-  } else { // Threre is no data in mesh file fill with zeros. (Scalar Data ???)
+  } else { // There is no data in mesh file fill with zeros.
+    std::clog << "There is no data found in the mesh file it will be replaced "
+                 "by dummy data.\n";
     mesh.data.resize(NumPoints);
     std::fill(mesh.data.begin(), mesh.data.end(), 0.0);
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,299 +1,270 @@
 #include <boost/filesystem/operations.hpp>
 #include <mesh.hpp>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <limits>
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <sstream>
 
-#include <vtkGenericDataObjectReader.h>
-#include <vtkSmartPointer.h>
-#include <vtkPoints.h>
-#include <vtkUnstructuredGrid.h>
-#include <vtkPointData.h>
 #include <vtkDoubleArray.h>
+#include <vtkGenericDataObjectReader.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
 #include <vtkUnstructuredGridWriter.h>
 
-namespace aste
-{
+namespace aste {
 
-  // --- MeshName
+// --- MeshName
 
-  std::string MeshName::filename() const { return _mname + ".vtk"; }
+std::string MeshName::filename() const { return _mname + ".vtk"; }
 
-  void MeshName::setDataname(std::string dataname) { _dname = dataname; }
+void MeshName::setDataname(std::string dataname) { _dname = dataname; }
 
-  std::string MeshName::dataname() const { return _dname; }
+std::string MeshName::dataname() const { return _dname; }
 
-  std::string MeshName::connectivityfilename() const { return _mname + ".conn.txt"; }
-
-  namespace
-  {
-    // Reads the main file containing the vertices and data
-    void readMainFile(Mesh &mesh, const std::string &filename, const std::string &dataname)
-    {
-
-      if (!fs::is_regular_file(filename))
-      {
-        throw std::invalid_argument{"The mesh file does not exist: " + filename};
-      }
-
-      vtkSmartPointer<vtkGenericDataObjectReader> reader =
-          vtkSmartPointer<vtkGenericDataObjectReader>::New();
-      reader->SetFileName(filename.c_str());
-      reader->SetReadAllScalars(true);
-      reader->SetReadAllVectors(true);
-      reader->ReadAllFieldsOn();
-      reader->Update();
-
-      //Get Points
-      vtkPoints *Points = reader->GetUnstructuredGridOutput()->GetPoints();
-      vtkIdType NumPoints = reader->GetUnstructuredGridOutput()->GetNumberOfPoints();
-      double vertexPos[3];
-      for (vtkIdType point = 0; point < NumPoints; point++)
-      {
-        Points->GetPoint(point, vertexPos);
-        // std::cout << "vertex = " << point <<  "x = " <<  vertexPos[0] << " y = " << vertexPos[1] << " z = " << vertexPos[2] << std::endl;
-        std::array<double, 3> vertexPosArr{vertexPos[0], vertexPos[1], vertexPos[2]};
-        mesh.positions.push_back(vertexPosArr);
-      }
-      // Get Point Data
-      vtkPointData *PD = reader->GetUnstructuredGridOutput()->GetPointData();
-      // Check it has data array
-      int check = PD->HasArray(dataname.c_str());
-      if (check == 1)
-      {
-        // Get Data and Add to Mesh
-        vtkDataArray *ArrayData = PD->GetArray(dataname.c_str());
-        int NumComp = ArrayData->GetNumberOfComponents();
-        switch (NumComp)
-        {
-        case 1: // Scalar Data
-          double scalar;
-          for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++)
-          {
-            scalar = ArrayData->GetTuple1(tupleIdx);
-            mesh.data.push_back(scalar);
-          }
-          break;
-
-        case 3: // Vector Data with 3 component
-          double *vectorref;
-          for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++)
-          {
-            vectorref = ArrayData->GetTuple3(tupleIdx);
-          }
-          break;
-        }
-      }
-      else
-      { // Threre is no data in mesh file fill with zeros. (Scalar Data ???)
-        mesh.data.resize(NumPoints);
-        std::fill(mesh.data.begin(), mesh.data.end(), 0.0);
-      }
-    }
-
-    // Reads the connectivity file containing the triangle and edge information
-    void readConnFile(Mesh &mesh, const std::string &filename)
-    {
-      if (!fs::is_regular_file(filename))
-      {
-        throw std::invalid_argument{"The mesh connectivity file does not exist: " + filename};
-      }
-      std::ifstream connFile{filename};
-      std::string line;
-      while (std::getline(connFile, line))
-      {
-        std::vector<std::string> parts;
-        boost::split(parts, line, [](char c)
-                     { return c == ' '; });
-        std::vector<size_t> indices(parts.size());
-        std::transform(parts.begin(), parts.end(), indices.begin(), [](const std::string &s) -> size_t
-                       { return std::stol(s); });
-
-        if (indices.size() == 3)
-        {
-          std::array<size_t, 3> elem{indices[0], indices[1], indices[2]};
-          mesh.triangles.push_back(elem);
-        }
-        else if (indices.size() == 2)
-        {
-          std::array<size_t, 2> elem{indices[0], indices[1]};
-          mesh.edges.push_back(elem);
-        }
-        else
-        {
-          throw std::runtime_error{std::string{"Invalid entry in connectivitiy file \""}.append(line).append("\"")};
-        }
-      }
-    }
-  }
-
-  Mesh MeshName::load() const
-  {
-    Mesh mesh;
-    readMainFile(mesh, filename(), dataname());
-    auto connFile = connectivityfilename();
-    if (boost::filesystem::exists(connFile))
-    {
-      readConnFile(mesh, connFile);
-    }
-    return mesh;
-  }
-
-  void MeshName::createDirectories() const
-  {
-    auto dir = fs::path(filename()).parent_path();
-    if (!dir.empty())
-    {
-      fs::create_directories(dir);
-    }
-  }
-
-  void MeshName::save(const Mesh &mesh) const
-  {
-    assert(mesh.positions.size() == mesh.data.size()); // Scalar Data ???
-
-    vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-    vtkDoubleArray *data = vtkDoubleArray::New();
-    data->SetName("scalar"); // This should be changed
-    data->SetNumberOfComponents(1);
-
-    for (size_t i = 0; i < mesh.positions.size() - 1; i++)
-    {
-      points->InsertNextPoint(mesh.positions[i][0], mesh.positions[i][1], mesh.positions[i][2]);
-      data->InsertNextTuple(&mesh.data[i]);
-    }
-
-    unstructuredGrid->SetPoints(points);
-    unstructuredGrid->GetPointData()->AddArray(data);
-
-    // Write file
-    vtkSmartPointer<vtkUnstructuredGridWriter> writer = vtkSmartPointer<vtkUnstructuredGridWriter>::New();
-    writer->SetInputData(unstructuredGrid);
-    writer->SetFileName(filename().c_str());
-
-    writer->Write();
-  }
-
-  std::ostream &operator<<(std::ostream &out, const MeshName &mname)
-  {
-    return out << mname.filename();
-  }
-
-  // --- BaseName
-
-  MeshName BaseName::with(const ExecutionContext &context) const
-  {
-    if (context.isParallel())
-    {
-      return {_bname + fs::path::preferred_separator + std::to_string(context.rank)};
-    }
-    else
-    {
-      return {_bname};
-    }
-  }
-
-  std::vector<MeshName> BaseName::findAll(const ExecutionContext &context) const
-  {
-    if (!context.isParallel())
-    {
-      // Check single timestep/meshfiles first
-      // Case: a single mesh
-      if (fs::is_regular_file(_bname + ".vtk"))
-      {
-        return {MeshName{_bname}};
-      }
-
-      // Check multiple timesteps
-      std::vector<MeshName> meshNames;
-      for (int t = 0; true; ++t)
-      {
-        std::string stepMeshName = _bname + ".dt" + std::to_string(t);
-        if (!fs::is_regular_file(stepMeshName + ".vtk"))
-          break;
-        meshNames.push_back(MeshName{stepMeshName});
-      }
-      std::cerr << "Names: " << meshNames.size() << '\n';
-      return meshNames;
-    }
-    else
-    {
-      fs::path rank{std::to_string(context.rank)};
-      // Is there a single partitioned mesh?
-      if (fs::is_directory(_bname))
-      {
-        auto rankMeshName = (fs::path(_bname) / rank).string();
-        if (fs::is_regular_file(rankMeshName + ".vtk"))
-        {
-          return {MeshName{rankMeshName}};
-        }
-      }
-
-      // Check multiple timesteps
-      std::vector<MeshName> meshNames;
-      for (int t = 0; true; ++t)
-      {
-        fs::path stepDirectory{_bname + ".dt" + std::to_string(t)};
-        auto rankMeshName = (stepDirectory / rank).string();
-        if (!(fs::is_directory(stepDirectory) && fs::is_regular_file(rankMeshName + ".vtk")))
-          break;
-        meshNames.push_back(MeshName{rankMeshName});
-      }
-      std::cerr << "Names: " << meshNames.size() << '\n';
-      return meshNames;
-    }
-  }
-
-  std::string Mesh::previewData(std::size_t max) const
-  {
-    if (data.empty() || max == 0)
-      return "<nothing>";
-
-    std::stringstream oss;
-    oss << data.front();
-    for (size_t i = 1; i < std::min(max, data.size()); ++i)
-      oss << ", " << data[i];
-    oss << " ...";
-    return oss.str();
-  }
-
-  std::string Mesh::summary() const
-  {
-    std::stringstream oss;
-    oss << positions.size() << " Vertices, " << data.size() << " Data Points, " << edges.size() << " Edges, " << triangles.size() << " Triangles";
-    return oss.str();
-  }
-
-  /// Creates a unique and element-wise ordered set of undirected edges.
-  std::vector<Mesh::Edge> gather_unique_edges(const Mesh &mesh)
-  {
-    std::vector<Mesh::Edge> sorted;
-    sorted.reserve(mesh.edges.size() + 3 * mesh.triangles.size());
-
-    for (auto const &edge : mesh.edges)
-    {
-      const auto a = edge[0];
-      const auto b = edge[1];
-      sorted.push_back(Mesh::Edge{std::min(a, b), std::max(a, b)});
-    }
-
-    for (auto const &triangle : mesh.triangles)
-    {
-      const auto a = triangle[0];
-      const auto b = triangle[1];
-      const auto c = triangle[2];
-      sorted.push_back(Mesh::Edge{std::min(a, b), std::max(a, b)});
-      sorted.push_back(Mesh::Edge{std::min(a, c), std::max(a, c)});
-      sorted.push_back(Mesh::Edge{std::min(b, c), std::max(b, c)});
-    }
-    std::sort(sorted.begin(), sorted.end(), EdgeCompare());
-    auto end = std::unique(sorted.begin(), sorted.end());
-    return std::vector<Mesh::Edge>(sorted.begin(), end);
-  }
-
+std::string MeshName::connectivityfilename() const {
+  return _mname + ".conn.txt";
 }
+
+namespace {
+// Reads the main file containing the vertices and data
+void readMainFile(Mesh &mesh, const std::string &filename,
+                  const std::string &dataname) {
+
+  if (!fs::is_regular_file(filename)) {
+    throw std::invalid_argument{"The mesh file does not exist: " + filename};
+  }
+
+  vtkSmartPointer<vtkGenericDataObjectReader> reader =
+      vtkSmartPointer<vtkGenericDataObjectReader>::New();
+  reader->SetFileName(filename.c_str());
+  reader->SetReadAllScalars(true);
+  reader->SetReadAllVectors(true);
+  reader->ReadAllFieldsOn();
+  reader->Update();
+
+  // Get Points
+  vtkPoints *Points = reader->GetUnstructuredGridOutput()->GetPoints();
+  vtkIdType NumPoints =
+      reader->GetUnstructuredGridOutput()->GetNumberOfPoints();
+  double vertexPos[3];
+  for (vtkIdType point = 0; point < NumPoints; point++) {
+    Points->GetPoint(point, vertexPos);
+    // std::cout << "vertex = " << point <<  "x = " <<  vertexPos[0] << " y = "
+    // << vertexPos[1] << " z = " << vertexPos[2] << std::endl;
+    std::array<double, 3> vertexPosArr{vertexPos[0], vertexPos[1],
+                                       vertexPos[2]};
+    mesh.positions.push_back(vertexPosArr);
+  }
+  // Get Point Data
+  vtkPointData *PD = reader->GetUnstructuredGridOutput()->GetPointData();
+  // Check it has data array
+  int check = PD->HasArray(dataname.c_str());
+  if (check == 1) {
+    // Get Data and Add to Mesh
+    vtkDataArray *ArrayData = PD->GetArray(dataname.c_str());
+    int NumComp = ArrayData->GetNumberOfComponents();
+    switch (NumComp) {
+    case 1: // Scalar Data
+      double scalar;
+      for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++) {
+        scalar = ArrayData->GetTuple1(tupleIdx);
+        mesh.data.push_back(scalar);
+      }
+      break;
+
+    case 3: // Vector Data with 3 component
+      double *vectorref;
+      for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++) {
+        vectorref = ArrayData->GetTuple3(tupleIdx);
+      }
+      break;
+    }
+  } else { // Threre is no data in mesh file fill with zeros. (Scalar Data ???)
+    mesh.data.resize(NumPoints);
+    std::fill(mesh.data.begin(), mesh.data.end(), 0.0);
+  }
+}
+
+// Reads the connectivity file containing the triangle and edge information
+void readConnFile(Mesh &mesh, const std::string &filename) {
+  if (!fs::is_regular_file(filename)) {
+    throw std::invalid_argument{"The mesh connectivity file does not exist: " +
+                                filename};
+  }
+  std::ifstream connFile{filename};
+  std::string line;
+  while (std::getline(connFile, line)) {
+    std::vector<std::string> parts;
+    boost::split(parts, line, [](char c) { return c == ' '; });
+    std::vector<size_t> indices(parts.size());
+    std::transform(parts.begin(), parts.end(), indices.begin(),
+                   [](const std::string &s) -> size_t { return std::stol(s); });
+
+    if (indices.size() == 3) {
+      std::array<size_t, 3> elem{indices[0], indices[1], indices[2]};
+      mesh.triangles.push_back(elem);
+    } else if (indices.size() == 2) {
+      std::array<size_t, 2> elem{indices[0], indices[1]};
+      mesh.edges.push_back(elem);
+    } else {
+      throw std::runtime_error{
+          std::string{"Invalid entry in connectivitiy file \""}
+              .append(line)
+              .append("\"")};
+    }
+  }
+}
+} // namespace
+
+Mesh MeshName::load() const {
+  Mesh mesh;
+  readMainFile(mesh, filename(), dataname());
+  auto connFile = connectivityfilename();
+  if (boost::filesystem::exists(connFile)) {
+    readConnFile(mesh, connFile);
+  }
+  return mesh;
+}
+
+void MeshName::createDirectories() const {
+  auto dir = fs::path(filename()).parent_path();
+  if (!dir.empty()) {
+    fs::create_directories(dir);
+  }
+}
+
+void MeshName::save(const Mesh &mesh) const {
+  assert(mesh.positions.size() == mesh.data.size()); // Scalar Data ???
+
+  vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid =
+      vtkSmartPointer<vtkUnstructuredGrid>::New();
+  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkDoubleArray *data = vtkDoubleArray::New();
+  data->SetName("scalar"); // This should be changed
+  data->SetNumberOfComponents(1);
+
+  for (size_t i = 0; i < mesh.positions.size() - 1; i++) {
+    points->InsertNextPoint(mesh.positions[i][0], mesh.positions[i][1],
+                            mesh.positions[i][2]);
+    data->InsertNextTuple(&mesh.data[i]);
+  }
+
+  unstructuredGrid->SetPoints(points);
+  unstructuredGrid->GetPointData()->AddArray(data);
+
+  // Write file
+  vtkSmartPointer<vtkUnstructuredGridWriter> writer =
+      vtkSmartPointer<vtkUnstructuredGridWriter>::New();
+  writer->SetInputData(unstructuredGrid);
+  writer->SetFileName(filename().c_str());
+
+  writer->Write();
+}
+
+std::ostream &operator<<(std::ostream &out, const MeshName &mname) {
+  return out << mname.filename();
+}
+
+// --- BaseName
+
+MeshName BaseName::with(const ExecutionContext &context) const {
+  if (context.isParallel()) {
+    return {_bname + fs::path::preferred_separator +
+            std::to_string(context.rank)};
+  } else {
+    return {_bname};
+  }
+}
+
+std::vector<MeshName> BaseName::findAll(const ExecutionContext &context) const {
+  if (!context.isParallel()) {
+    // Check single timestep/meshfiles first
+    // Case: a single mesh
+    if (fs::is_regular_file(_bname + ".vtk")) {
+      return {MeshName{_bname}};
+    }
+
+    // Check multiple timesteps
+    std::vector<MeshName> meshNames;
+    for (int t = 0; true; ++t) {
+      std::string stepMeshName = _bname + ".dt" + std::to_string(t);
+      if (!fs::is_regular_file(stepMeshName + ".vtk"))
+        break;
+      meshNames.push_back(MeshName{stepMeshName});
+    }
+    std::cerr << "Names: " << meshNames.size() << '\n';
+    return meshNames;
+  } else {
+    fs::path rank{std::to_string(context.rank)};
+    // Is there a single partitioned mesh?
+    if (fs::is_directory(_bname)) {
+      auto rankMeshName = (fs::path(_bname) / rank).string();
+      if (fs::is_regular_file(rankMeshName + ".vtk")) {
+        return {MeshName{rankMeshName}};
+      }
+    }
+
+    // Check multiple timesteps
+    std::vector<MeshName> meshNames;
+    for (int t = 0; true; ++t) {
+      fs::path stepDirectory{_bname + ".dt" + std::to_string(t)};
+      auto rankMeshName = (stepDirectory / rank).string();
+      if (!(fs::is_directory(stepDirectory) &&
+            fs::is_regular_file(rankMeshName + ".vtk")))
+        break;
+      meshNames.push_back(MeshName{rankMeshName});
+    }
+    std::cerr << "Names: " << meshNames.size() << '\n';
+    return meshNames;
+  }
+}
+
+std::string Mesh::previewData(std::size_t max) const {
+  if (data.empty() || max == 0)
+    return "<nothing>";
+
+  std::stringstream oss;
+  oss << data.front();
+  for (size_t i = 1; i < std::min(max, data.size()); ++i)
+    oss << ", " << data[i];
+  oss << " ...";
+  return oss.str();
+}
+
+std::string Mesh::summary() const {
+  std::stringstream oss;
+  oss << positions.size() << " Vertices, " << data.size() << " Data Points, "
+      << edges.size() << " Edges, " << triangles.size() << " Triangles";
+  return oss.str();
+}
+
+/// Creates a unique and element-wise ordered set of undirected edges.
+std::vector<Mesh::Edge> gather_unique_edges(const Mesh &mesh) {
+  std::vector<Mesh::Edge> sorted;
+  sorted.reserve(mesh.edges.size() + 3 * mesh.triangles.size());
+
+  for (auto const &edge : mesh.edges) {
+    const auto a = edge[0];
+    const auto b = edge[1];
+    sorted.push_back(Mesh::Edge{std::min(a, b), std::max(a, b)});
+  }
+
+  for (auto const &triangle : mesh.triangles) {
+    const auto a = triangle[0];
+    const auto b = triangle[1];
+    const auto c = triangle[2];
+    sorted.push_back(Mesh::Edge{std::min(a, b), std::max(a, b)});
+    sorted.push_back(Mesh::Edge{std::min(a, c), std::max(a, c)});
+    sorted.push_back(Mesh::Edge{std::min(b, c), std::max(b, c)});
+  }
+  std::sort(sorted.begin(), sorted.end(), EdgeCompare());
+  auto end = std::unique(sorted.begin(), sorted.end());
+  return std::vector<Mesh::Edge>(sorted.begin(), end);
+}
+
+} // namespace aste

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -61,8 +61,7 @@ void readMainFile(Mesh &mesh, const std::string &filename,
   // Get Point Data
   vtkPointData *PD = reader->GetUnstructuredGridOutput()->GetPointData();
   // Check it has data array
-  int check = PD->HasArray(dataname.c_str());
-  if (check == 1) {
+  if (PD->HasArray(dataname.c_str()) == 1) {
     // Get Data and Add to Mesh
     vtkDataArray *ArrayData = PD->GetArray(dataname.c_str());
     int NumComp = ArrayData->GetNumberOfComponents();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -136,14 +136,14 @@ void MeshName::createDirectories() const {
   }
 }
 
-void MeshName::save(const Mesh &mesh) const {
+void MeshName::save(const Mesh &mesh, const std::string &dataname) const {
   assert(mesh.positions.size() == mesh.data.size()); // Scalar Data ???
 
   vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid =
       vtkSmartPointer<vtkUnstructuredGrid>::New();
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
   vtkDoubleArray *data = vtkDoubleArray::New();
-  data->SetName("scalar"); // This should be changed
+  data->SetName(dataname.c_str());
   data->SetNumberOfComponents(1);
 
   for (size_t i = 0; i < mesh.positions.size() - 1; i++) {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -45,27 +45,26 @@ namespace aste
       reader->ReadAllFieldsOn();
       reader->Update();
 
+           //Get Points
+      vtkPoints *Points = reader->GetUnstructuredGridOutput()->GetPoints();
+      vtkIdType NumPoints = reader->GetUnstructuredGridOutput()->GetNumberOfPoints();
+      std::cout << "Number of Points = " << NumPoints << std::endl;
+      double vertexPos[3];
+      for (vtkIdType point = 0; point < NumPoints; point++)
+      {
+        Points->GetPoint(point, vertexPos);
+       // std::cout << "vertex = " << point <<  "x = " <<  vertexPos[0] << " y = " << vertexPos[1] << " z = " << vertexPos[2] << std::endl;
+        std::array<double, 3> vertexPosArr{vertexPos[0], vertexPos[1], vertexPos[2]};
+        mesh.positions.push_back(vertexPosArr);
+      }
+
       // Get Point Data
       vtkPointData *PD = reader->GetUnstructuredGridOutput()->GetPointData();
       // Check it has data array
 
       int check = PD->HasArray(dataname.c_str());
-      if (check == 0)
+      if (check == 1)
       {
-        throw std::invalid_argument{"The mesh file does not contain data array: " + dataname};
-      }
-
-      //Get Points
-      vtkPoints *Points = reader->GetUnstructuredGridOutput()->GetPoints();
-      vtkIdType NumPoints = reader->GetUnstructuredGridOutput()->GetNumberOfPoints();
-      double vertexPos[3];
-      for (vtkIdType point = 0; point < NumPoints; point++)
-      {
-        Points->GetPoint(point, vertexPos);
-        std::array<double, 3> vertexPosArr{vertexPos[0], vertexPos[1], vertexPos[2]};
-        mesh.positions.push_back(vertexPosArr);
-      }
-
       // Get Data and Add to Mesh
       vtkDataArray *ArrayData = PD->GetArray(dataname.c_str());
       int NumComp = ArrayData->GetNumberOfComponents();
@@ -88,6 +87,14 @@ namespace aste
         }
         break;
       }
+      } else { // Threre is no data in mesh file fill with zeros.
+           for (vtkIdType point = 0; point < NumPoints; point++)
+      {
+   mesh.data.push_back(0.0);
+      }
+      }
+
+ 
     }
 
     // Reads the connectivity file containing the triangle and edge information

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -54,8 +54,6 @@ void readMainFile(Mesh &mesh, const std::string &filename,
   double vertexPos[3];
   for (vtkIdType point = 0; point < NumPoints; point++) {
     Points->GetPoint(point, vertexPos);
-    // std::cout << "vertex = " << point <<  "x = " <<  vertexPos[0] << " y = "
-    // << vertexPos[1] << " z = " << vertexPos[2] << std::endl;
     std::array<double, 3> vertexPosArr{vertexPos[0], vertexPos[1],
                                        vertexPos[2]};
     mesh.positions.push_back(vertexPosArr);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -68,9 +68,9 @@ void readMainFile(Mesh &mesh, const std::string &filename,
     int NumComp = ArrayData->GetNumberOfComponents();
     switch (NumComp) {
     case 1: // Scalar Data
-      double scalar;
+     
       for (vtkIdType tupleIdx = 0; tupleIdx < NumPoints; tupleIdx++) {
-        scalar = ArrayData->GetTuple1(tupleIdx);
+        const double scalar = ArrayData->GetTuple1(tupleIdx);
         mesh.data.push_back(scalar);
       }
       break;

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -46,7 +46,7 @@ namespace aste
 
     Mesh load() const;
 
-    void save(const Mesh &mesh) const;
+    void save(const Mesh &mesh, const std::string &dataname) const;
 
     void setDataname(std::string);
 

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -7,84 +7,98 @@
 #include <iosfwd>
 #include <cassert>
 
-namespace aste {
+namespace aste
+{
 
-namespace fs = boost::filesystem;
-class BaseName;
-struct Mesh;
-class MeshName;
+  namespace fs = boost::filesystem;
+  class BaseName;
+  struct Mesh;
+  class MeshName;
 
-class MeshException : public std::runtime_error {
+  class MeshException : public std::runtime_error
+  {
   public:
-    MeshException(const std::string& what_arg):std::runtime_error(what_arg){};
-};
-
-struct ExecutionContext {
-  ExecutionContext() = default;
-  ExecutionContext(int rank, int size) : rank(rank), size(size) {
-    assert(0 <= rank && rank < size);
+    MeshException(const std::string &what_arg) : std::runtime_error(what_arg){};
   };
-  int rank{0};
-  int size{1};
-  bool isParallel() const { return size > 1; }
-};
 
-class MeshName {
-public:
-  MeshName() = default;
+  struct ExecutionContext
+  {
+    ExecutionContext() = default;
+    ExecutionContext(int rank, int size) : rank(rank), size(size)
+    {
+      assert(0 <= rank && rank < size);
+    };
+    int rank{0};
+    int size{1};
+    bool isParallel() const { return size > 1; }
+  };
 
-  std::string filename() const;
+  class MeshName
+  {
+  public:
+    MeshName() = default;
 
-  std::string connectivityfilename() const;
+    std::string filename() const;
 
-  Mesh load() const;
+    std::string dataname() const;
 
-  void save(const Mesh& mesh) const;
+    std::string connectivityfilename() const;
 
-private:
+    Mesh load() const;
 
-  MeshName(std::string meshname) : _mname(std::move(meshname)) {}
+    void save(const Mesh &mesh) const;
 
-  void createDirectories() const;
+    void setDataname(std::string);
 
-  std::string _mname;
+  private:
+    MeshName(std::string meshname) : _mname(std::move(meshname)) {}
 
-  friend BaseName;
-};
+    void createDirectories() const;
 
-std::ostream& operator<<(std::ostream& out, const MeshName& mname);
+    std::string _mname;
 
-class BaseName {
-public:
-  BaseName(std::string basename) : _bname(std::move(basename)) {}
+    std::string _dname;
 
-  MeshName with(const ExecutionContext &context) const;
+    friend BaseName;
+  };
 
-  std::vector<MeshName> findAll(const ExecutionContext &context) const;
+  std::ostream &operator<<(std::ostream &out, const MeshName &mname);
 
-private:
-  std::string _bname;
-};
+  class BaseName
+  {
+  public:
+    BaseName(std::string basename) : _bname(std::move(basename)) {}
 
-struct Mesh {
-  using Vertex = std::array<double, 3>;
-  using Edge = std::array<size_t, 2>;
-  using Triangle = std::array<size_t, 3>;
-  std::vector<Vertex> positions;
-  std::vector<Edge> edges;
-  std::vector<Triangle> triangles;
-  std::vector<double> data;
+    MeshName with(const ExecutionContext &context) const;
 
-  std::string previewData(std::size_t max = 10) const;
-  std::string summary() const;
-};
+    std::vector<MeshName> findAll(const ExecutionContext &context) const;
 
-struct EdgeCompare {
-  bool operator()(const Mesh::Edge& lhs, const Mesh::Edge& rhs) const {
-    return lhs[0] < rhs[0] || (lhs[0] == rhs[0] && lhs[1] < rhs[1]);
-  }
-};
+  private:
+    std::string _bname;
+  };
 
-std::vector<Mesh::Edge> gather_unique_edges(const Mesh& mesh);
+  struct Mesh
+  {
+    using Vertex = std::array<double, 3>;
+    using Edge = std::array<size_t, 2>;
+    using Triangle = std::array<size_t, 3>;
+    std::vector<Vertex> positions;
+    std::vector<Edge> edges;
+    std::vector<Triangle> triangles;
+    std::vector<double> data;
+
+    std::string previewData(std::size_t max = 10) const;
+    std::string summary() const;
+  };
+
+  struct EdgeCompare
+  {
+    bool operator()(const Mesh::Edge &lhs, const Mesh::Edge &rhs) const
+    {
+      return lhs[0] < rhs[0] || (lhs[0] == rhs[0] && lhs[1] < rhs[1]);
+    }
+  };
+
+  std::vector<Mesh::Edge> gather_unique_edges(const Mesh &mesh);
 
 } // namespace aste

--- a/src/metisAPI.cpp
+++ b/src/metisAPI.cpp
@@ -1,19 +1,20 @@
-#include <metis.h>
 #include <iostream>
+#include <metis.h>
 #include <vector>
-extern "C" void partitionMetis(idx_t cell_count, idx_t point_count, idx_t* cellptr, idx_t* celldata, idx_t nparts, idx_t* point_partition);
+extern "C" void partitionMetis(idx_t cell_count, idx_t point_count,
+                               idx_t *cellptr, idx_t *celldata, idx_t nparts,
+                               idx_t *point_partition);
 extern "C" int typewidth();
 
-void partitionMetis(idx_t cell_count, idx_t point_count, idx_t* cellptr, idx_t* celldata, idx_t nparts, idx_t* point_partition)
-{
-    idx_t options[METIS_NOPTIONS];
-    METIS_SetDefaultOptions(options);
-    std::vector<idx_t> cell_partition(cell_count);
-    idx_t objval;
-    int result = METIS_PartMeshNodal(&cell_count, &point_count, cellptr, celldata, 0, 0, &nparts, 0, options, &objval, cell_partition.data(), point_partition);
+void partitionMetis(idx_t cell_count, idx_t point_count, idx_t *cellptr,
+                    idx_t *celldata, idx_t nparts, idx_t *point_partition) {
+  idx_t options[METIS_NOPTIONS];
+  METIS_SetDefaultOptions(options);
+  std::vector<idx_t> cell_partition(cell_count);
+  idx_t objval;
+  int result = METIS_PartMeshNodal(&cell_count, &point_count, cellptr, celldata,
+                                   0, 0, &nparts, 0, options, &objval,
+                                   cell_partition.data(), point_partition);
 }
 
-int typewidth()
-{
-    return IDXTYPEWIDTH;
-}
+int typewidth() { return IDXTYPEWIDTH; }

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -290,7 +290,8 @@ def write_meshes(meshes, recoveryInfo, dirname):
     os.mkdir(dirname)
     for i in range(len(meshes)):
         mesh = meshes[i]
-        mesh_io.write_txt(dirname + "/" + str(i), mesh.points, mesh.cells, mesh.pointdata)
+  mesh_io.write_vtk(dirname + "/" + str(i) + ".vtk", mesh.points,
+                          mesh.cells, mesh.cell_types, mesh.pointdata)
     json.dump(recoveryInfo, open(recoveryName, "w"))
         
 def parse_args():

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -1,14 +1,14 @@
-#include <string>
-#include <boost/filesystem.hpp>
+#include "precice/SolverInterface.hpp"
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
+#include <boost/filesystem.hpp>
 #include <mpi.h>
-#include "precice/SolverInterface.hpp"
+#include <string>
 //#include "utils/EventUtils.hpp"
 #include <algorithm>
 #include <cassert>
-#include <functional>
 #include <exception>
+#include <functional>
 
 #include "common.hpp"
 #include "easylogging++.h"
@@ -22,39 +22,31 @@ namespace fs = boost::filesystem;
 using VertexID = int;
 using EdgeID = int;
 
-struct Edge
-{
+struct Edge {
   Edge(VertexID a, VertexID b) : vA(std::min(a, b)), vB(std::max(a, b)) {}
   VertexID vA;
   VertexID vB;
 };
 
-bool operator==(const Edge &lhs, const Edge &rhs)
-{
+bool operator==(const Edge &lhs, const Edge &rhs) {
   return (lhs.vA == rhs.vA) && (lhs.vB == rhs.vB);
 }
 
-bool operator<(const Edge &lhs, const Edge &rhs)
-{
+bool operator<(const Edge &lhs, const Edge &rhs) {
   return (lhs.vA < rhs.vA) || ((lhs.vA == rhs.vA) && (lhs.vB < rhs.vB));
 }
 
-namespace std
-{
-  template <>
-  struct hash<Edge>
-  {
-    using argument_type = Edge;
-    using result_type = std::size_t;
-    result_type operator()(argument_type const &e) const noexcept
-    {
-      return std::hash<int>{}(e.vA) ^ std::hash<int>{}(e.vB);
-    }
-  };
+namespace std {
+template <> struct hash<Edge> {
+  using argument_type = Edge;
+  using result_type = std::size_t;
+  result_type operator()(argument_type const &e) const noexcept {
+    return std::hash<int>{}(e.vA) ^ std::hash<int>{}(e.vB);
+  }
 };
+}; // namespace std
 
-aste::ExecutionContext initializeMPI(int argc, char *argv[])
-{
+aste::ExecutionContext initializeMPI(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
   int rank = 0, size = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -63,19 +55,18 @@ aste::ExecutionContext initializeMPI(int argc, char *argv[])
 }
 
 std::vector<int> setupVertexIDs(precice::SolverInterface &interface,
-                                const aste::Mesh &mesh, int meshID)
-{
+                                const aste::Mesh &mesh, int meshID) {
 #ifdef ASTE_SET_MESH_BLOCK
   const auto nvertices = mesh.positions.size();
   std::vector<double> posData(3 * nvertices);
-  for (unsigned long i = 0; i < nvertices; ++i)
-  {
+  for (unsigned long i = 0; i < nvertices; ++i) {
     const auto &pos = mesh.positions[i];
     std::copy(pos.begin(), pos.end(), &posData[i * 3]);
   }
 
   std::vector<int> vertexIDs(nvertices);
-  interface.setMeshVertices(meshID, nvertices, posData.data(), vertexIDs.data());
+  interface.setMeshVertices(meshID, nvertices, posData.data(),
+                            vertexIDs.data());
   return vertexIDs;
 #else
   std::vector<int> vertexIDs;
@@ -88,8 +79,9 @@ std::vector<int> setupVertexIDs(precice::SolverInterface &interface,
 
 using EdgeIdMap = boost::container::flat_map<Edge, EdgeID>;
 
-EdgeIdMap setupEdgeIDs(precice::SolverInterface &interface, const aste::Mesh &mesh, int meshID, const std::vector<int> &vertexIDs)
-{
+EdgeIdMap setupEdgeIDs(precice::SolverInterface &interface,
+                       const aste::Mesh &mesh, int meshID,
+                       const std::vector<int> &vertexIDs) {
   VLOG(1) << "Mesh Setup: 2.1) Gather Unique Edges";
   const auto unique_edges{gather_unique_edges(mesh)};
 
@@ -97,8 +89,7 @@ EdgeIdMap setupEdgeIDs(precice::SolverInterface &interface, const aste::Mesh &me
   boost::container::flat_map<Edge, EdgeID> edgeMap;
   edgeMap.reserve(unique_edges.size());
 
-  for (auto const &edge : unique_edges)
-  {
+  for (auto const &edge : unique_edges) {
     const auto a = vertexIDs.at(edge[0]);
     const auto b = vertexIDs.at(edge[1]);
     assert(a != b);
@@ -108,8 +99,8 @@ EdgeIdMap setupEdgeIDs(precice::SolverInterface &interface, const aste::Mesh &me
   return edgeMap;
 }
 
-std::vector<int> setupMesh(precice::SolverInterface &interface, const aste::Mesh &mesh, int meshID)
-{
+std::vector<int> setupMesh(precice::SolverInterface &interface,
+                           const aste::Mesh &mesh, int meshID) {
   auto tstart = std::chrono::steady_clock::now();
 
   VLOG(1) << "Mesh Setup: 1) Vertices";
@@ -120,29 +111,33 @@ std::vector<int> setupMesh(precice::SolverInterface &interface, const aste::Mesh
   const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
 
   VLOG(1) << "Mesh Setup: 3) Triangles";
-  for (auto const &triangle : mesh.triangles)
-  {
+  for (auto const &triangle : mesh.triangles) {
     const auto a = vertexIDs[triangle[0]];
     const auto b = vertexIDs[triangle[1]];
     const auto c = vertexIDs[triangle[2]];
 
-    interface.setMeshTriangle(meshID,
-                              edgeMap.at(Edge{a, b}),
-                              edgeMap.at(Edge{b, c}),
-                              edgeMap.at(Edge{c, a}));
+    interface.setMeshTriangle(meshID, edgeMap.at(Edge{a, b}),
+                              edgeMap.at(Edge{b, c}), edgeMap.at(Edge{c, a}));
   }
   auto tend = std::chrono::steady_clock::now();
 
-  VLOG(1)
-      << "Mesh Setup Took "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tstart).count() << "ms ("
-      << std::chrono::duration_cast<std::chrono::milliseconds>(tconnectivity - tstart).count() << "ms for vertices, "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tconnectivity).count() << "ms for connectivity)";
+  VLOG(1) << "Mesh Setup Took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(tend -
+                                                                   tstart)
+                 .count()
+          << "ms ("
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 tconnectivity - tstart)
+                 .count()
+          << "ms for vertices, "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 tend - tconnectivity)
+                 .count()
+          << "ms for connectivity)";
   return vertexIDs;
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   START_EASYLOGGINGPP(argc, argv);
   auto context = initializeMPI(argc, argv);
   auto options = getOptions(argc, argv);
@@ -151,20 +146,24 @@ int main(int argc, char *argv[])
   const std::string dataname = options["data"].as<std::string>();
 
   auto meshes = aste::BaseName(meshname).findAll(context);
-  if (meshes.empty())
-  {
-    throw std::invalid_argument("ERROR: Could not find meshes for name: " + meshname);
+  if (meshes.empty()) {
+    throw std::invalid_argument("ERROR: Could not find meshes for name: " +
+                                meshname);
   }
-  for (auto &mesh : meshes)
-  {
+  for (auto &mesh : meshes) {
     mesh.setDataname(dataname);
   }
 
   // Create and configure solver interface
-  precice::SolverInterface interface(participant, options["precice-config"].as<std::string>(), context.rank, context.size);
-  //precice::utils::EventRegistry::instance().runName =  options["runName"].as<std::string>();
+  precice::SolverInterface interface(
+      participant, options["precice-config"].as<std::string>(), context.rank,
+      context.size);
+  // precice::utils::EventRegistry::instance().runName =
+  // options["runName"].as<std::string>();
 
-  const int meshID = interface.getMeshID((participant == "A") ? "MeshA" : "MeshB"); // participant = A => MeshID = MeshA
+  const int meshID = interface.getMeshID(
+      (participant == "A") ? "MeshA"
+                           : "MeshB"); // participant = A => MeshID = MeshA
   const int dataID = interface.getDataID("Data", meshID);
 
   VLOG(1) << "Loading mesh from " << meshes.front().filename();
@@ -177,10 +176,11 @@ int main(int argc, char *argv[])
 
   interface.initialize();
 
-  if (interface.isActionRequired(precice::constants::actionWriteInitialData()))
-  {
+  if (interface.isActionRequired(
+          precice::constants::actionWriteInitialData())) {
     VLOG(1) << "Write initial data for participant " << participant;
-    interface.writeBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
+    interface.writeBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(),
+                                   mesh.data.data());
     VLOG(1) << "Data written: " << mesh.previewData();
 
     interface.markActionFulfilled(precice::constants::actionWriteInitialData());
@@ -188,22 +188,21 @@ int main(int argc, char *argv[])
   interface.initializeData();
 
   size_t round = 0;
-  while (interface.isCouplingOngoing() and round < meshes.size())
-  {
-    if (participant == "A")
-    {
+  while (interface.isCouplingOngoing() and round < meshes.size()) {
+    if (participant == "A") {
       VLOG(1) << "Read mesh for t=" << round << " from " << meshes[round];
       auto roundmesh = meshes[round].load();
       VLOG(1) << "This roundmesh contains: " << roundmesh.summary();
       assert(roundmesh.data.size() == vertexIDs.size());
-      interface.writeBlockScalarData(dataID, roundmesh.data.size(), vertexIDs.data(), roundmesh.data.data());
+      interface.writeBlockScalarData(dataID, roundmesh.data.size(),
+                                     vertexIDs.data(), roundmesh.data.data());
       VLOG(1) << "Data written: " << mesh.previewData();
     }
     interface.advance(1);
 
-    if (participant == "B")
-    {
-      interface.readBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
+    if (participant == "B") {
+      interface.readBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(),
+                                    mesh.data.data());
       VLOG(1) << "Data read: " << mesh.previewData();
     }
     round++;
@@ -212,24 +211,19 @@ int main(int argc, char *argv[])
   interface.finalize();
 
   // Write out results in same format as data was read
-  if (participant == "B")
-  {
-    auto meshName = aste::BaseName{options["output"].as<std::string>()}.with(context);
+  if (participant == "B") {
+    auto meshName =
+        aste::BaseName{options["output"].as<std::string>()}.with(context);
     auto filename = fs::path(meshName.filename());
-    if (context.rank == 0 && fs::exists(filename))
-    {
-      if (context.isParallel())
-      {
+    if (context.rank == 0 && fs::exists(filename)) {
+      if (context.isParallel()) {
         // Remove the directory <meshName>/<rank>.txt
         auto dir = filename.parent_path();
-        if (!dir.empty())
-        {
+        if (!dir.empty()) {
           fs::remove_all(dir);
           fs::create_directory(dir);
         }
-      }
-      else
-      {
+      } else {
         // Remove the mesh file <meshName>.txt
         fs::remove(filename);
       }

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -231,7 +231,7 @@ int main(int argc, char *argv[]) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     VLOG(1) << "Writing results to " << filename;
-    meshName.save(mesh,dataname);
+    meshName.save(mesh, dataname);
   }
 
   MPI_Finalize();

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -231,7 +231,7 @@ int main(int argc, char *argv[]) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     VLOG(1) << "Writing results to " << filename;
-    meshName.save(mesh);
+    meshName.save(mesh,dataname);
   }
 
   MPI_Finalize();

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -22,31 +22,39 @@ namespace fs = boost::filesystem;
 using VertexID = int;
 using EdgeID = int;
 
-struct Edge {
-    Edge(VertexID a, VertexID b) : vA(std::min(a,b)), vB(std::max(a,b)) {}
-    VertexID vA;
-    VertexID vB;
+struct Edge
+{
+  Edge(VertexID a, VertexID b) : vA(std::min(a, b)), vB(std::max(a, b)) {}
+  VertexID vA;
+  VertexID vB;
 };
 
-bool operator==(const Edge& lhs, const Edge& rhs) {
-    return (lhs.vA == rhs.vA) && (lhs.vB == rhs.vB);
+bool operator==(const Edge &lhs, const Edge &rhs)
+{
+  return (lhs.vA == rhs.vA) && (lhs.vB == rhs.vB);
 }
 
-bool operator<(const Edge& lhs, const Edge& rhs) {
-    return (lhs.vA < rhs.vA) || ( (lhs.vA == rhs.vA) && (lhs.vB < rhs.vB) );
+bool operator<(const Edge &lhs, const Edge &rhs)
+{
+  return (lhs.vA < rhs.vA) || ((lhs.vA == rhs.vA) && (lhs.vB < rhs.vB));
 }
 
-namespace std {
-    template<> struct hash<Edge> {
-        using argument_type = Edge;
-        using result_type = std::size_t;
-        result_type operator()(argument_type const& e) const noexcept {
-            return std::hash<int>{}(e.vA) ^ std::hash<int>{}(e.vB);
-        }
-    };
+namespace std
+{
+  template <>
+  struct hash<Edge>
+  {
+    using argument_type = Edge;
+    using result_type = std::size_t;
+    result_type operator()(argument_type const &e) const noexcept
+    {
+      return std::hash<int>{}(e.vA) ^ std::hash<int>{}(e.vB);
+    }
+  };
 };
 
-aste::ExecutionContext initializeMPI(int argc, char* argv[]) {
+aste::ExecutionContext initializeMPI(int argc, char *argv[])
+{
   MPI_Init(&argc, &argv);
   int rank = 0, size = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -54,15 +62,16 @@ aste::ExecutionContext initializeMPI(int argc, char* argv[]) {
   return {rank, size};
 }
 
-
 std::vector<int> setupVertexIDs(precice::SolverInterface &interface,
-                                const aste::Mesh &mesh, int meshID) {
+                                const aste::Mesh &mesh, int meshID)
+{
 #ifdef ASTE_SET_MESH_BLOCK
   const auto nvertices = mesh.positions.size();
   std::vector<double> posData(3 * nvertices);
-  for (unsigned long i = 0; i<nvertices; ++i) {
-    const auto& pos = mesh.positions[i];
-    std::copy(pos.begin(), pos.end(), &posData[i*3]);
+  for (unsigned long i = 0; i < nvertices; ++i)
+  {
+    const auto &pos = mesh.positions[i];
+    std::copy(pos.begin(), pos.end(), &posData[i * 3]);
   }
 
   std::vector<int> vertexIDs(nvertices);
@@ -79,25 +88,28 @@ std::vector<int> setupVertexIDs(precice::SolverInterface &interface,
 
 using EdgeIdMap = boost::container::flat_map<Edge, EdgeID>;
 
-EdgeIdMap setupEdgeIDs(precice::SolverInterface& interface, const aste::Mesh& mesh, int meshID, const std::vector<int>& vertexIDs) {
-    VLOG(1) << "Mesh Setup: 2.1) Gather Unique Edges";
-    const auto unique_edges{gather_unique_edges(mesh)};
+EdgeIdMap setupEdgeIDs(precice::SolverInterface &interface, const aste::Mesh &mesh, int meshID, const std::vector<int> &vertexIDs)
+{
+  VLOG(1) << "Mesh Setup: 2.1) Gather Unique Edges";
+  const auto unique_edges{gather_unique_edges(mesh)};
 
-    VLOG(1) << "Mesh Setup: 2.2) Register Edges";
-    boost::container::flat_map<Edge, EdgeID> edgeMap;
-    edgeMap.reserve(unique_edges.size());
+  VLOG(1) << "Mesh Setup: 2.2) Register Edges";
+  boost::container::flat_map<Edge, EdgeID> edgeMap;
+  edgeMap.reserve(unique_edges.size());
 
-    for (auto const &edge : unique_edges) {
-      const auto a = vertexIDs.at(edge[0]);
-      const auto b = vertexIDs.at(edge[1]);
-      assert(a != b);
-      EdgeID eid = interface.setMeshEdge(meshID, a, b);
-      edgeMap.emplace_hint(edgeMap.end(), Edge{a, b}, eid);
-    }
-    return edgeMap;
+  for (auto const &edge : unique_edges)
+  {
+    const auto a = vertexIDs.at(edge[0]);
+    const auto b = vertexIDs.at(edge[1]);
+    assert(a != b);
+    EdgeID eid = interface.setMeshEdge(meshID, a, b);
+    edgeMap.emplace_hint(edgeMap.end(), Edge{a, b}, eid);
+  }
+  return edgeMap;
 }
 
-std::vector<int> setupMesh(precice::SolverInterface& interface, const aste::Mesh& mesh, int meshID) {
+std::vector<int> setupMesh(precice::SolverInterface &interface, const aste::Mesh &mesh, int meshID)
+{
   auto tstart = std::chrono::steady_clock::now();
 
   VLOG(1) << "Mesh Setup: 1) Vertices";
@@ -108,48 +120,53 @@ std::vector<int> setupMesh(precice::SolverInterface& interface, const aste::Mesh
   const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
 
   VLOG(1) << "Mesh Setup: 3) Triangles";
-  for (auto const & triangle : mesh.triangles) {
-      const auto a = vertexIDs[triangle[0]];
-      const auto b = vertexIDs[triangle[1]];
-      const auto c = vertexIDs[triangle[2]];
+  for (auto const &triangle : mesh.triangles)
+  {
+    const auto a = vertexIDs[triangle[0]];
+    const auto b = vertexIDs[triangle[1]];
+    const auto c = vertexIDs[triangle[2]];
 
-      interface.setMeshTriangle( meshID, 
-              edgeMap.at(Edge{a,b}),
-              edgeMap.at(Edge{b,c}),
-              edgeMap.at(Edge{c,a})
-              );
+    interface.setMeshTriangle(meshID,
+                              edgeMap.at(Edge{a, b}),
+                              edgeMap.at(Edge{b, c}),
+                              edgeMap.at(Edge{c, a}));
   }
   auto tend = std::chrono::steady_clock::now();
 
   VLOG(1)
-    << "Mesh Setup Took "
-    << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tstart).count() << "ms ("
-    << std::chrono::duration_cast<std::chrono::milliseconds>(tconnectivity - tstart).count() << "ms for vertices, "
-    << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tconnectivity).count() << "ms for connectivity)";
+      << "Mesh Setup Took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tstart).count() << "ms ("
+      << std::chrono::duration_cast<std::chrono::milliseconds>(tconnectivity - tstart).count() << "ms for vertices, "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tconnectivity).count() << "ms for connectivity)";
   return vertexIDs;
 }
 
-
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   START_EASYLOGGINGPP(argc, argv);
   auto context = initializeMPI(argc, argv);
   auto options = getOptions(argc, argv);
   const std::string meshname = options["mesh"].as<std::string>();
   const std::string participant = options["participant"].as<std::string>();
+  const std::string dataname = options["data"].as<std::string>();
 
   auto meshes = aste::BaseName(meshname).findAll(context);
-  if (meshes.empty()) {
+  if (meshes.empty())
+  {
     throw std::invalid_argument("ERROR: Could not find meshes for name: " + meshname);
+  }
+  for (auto &mesh : meshes)
+  {
+    mesh.setDataname(dataname);
   }
 
   // Create and configure solver interface
   precice::SolverInterface interface(participant, options["precice-config"].as<std::string>(), context.rank, context.size);
   //precice::utils::EventRegistry::instance().runName =  options["runName"].as<std::string>();
-  
-  const int meshID = interface.getMeshID( (participant == "A") ? "MeshA" : "MeshB" ); // participant = A => MeshID = MeshA
+
+  const int meshID = interface.getMeshID((participant == "A") ? "MeshA" : "MeshB"); // participant = A => MeshID = MeshA
   const int dataID = interface.getDataID("Data", meshID);
-  
+
   VLOG(1) << "Loading mesh from " << meshes.front().filename();
   // reads in mesh, 0 data for participant B
   auto mesh = meshes.front().load();
@@ -157,10 +174,11 @@ int main(int argc, char* argv[])
 
   std::vector<int> vertexIDs = setupMesh(interface, mesh, meshID);
   VLOG(1) << "Mesh setup completed on Rank " << context.rank;
-    
+
   interface.initialize();
 
-  if (interface.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (interface.isActionRequired(precice::constants::actionWriteInitialData()))
+  {
     VLOG(1) << "Write initial data for participant " << participant;
     interface.writeBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
     VLOG(1) << "Data written: " << mesh.previewData();
@@ -170,8 +188,10 @@ int main(int argc, char* argv[])
   interface.initializeData();
 
   size_t round = 0;
-  while (interface.isCouplingOngoing() and round < meshes.size()) {
-    if (participant == "A") {
+  while (interface.isCouplingOngoing() and round < meshes.size())
+  {
+    if (participant == "A")
+    {
       VLOG(1) << "Read mesh for t=" << round << " from " << meshes[round];
       auto roundmesh = meshes[round].load();
       VLOG(1) << "This roundmesh contains: " << roundmesh.summary();
@@ -181,7 +201,8 @@ int main(int argc, char* argv[])
     }
     interface.advance(1);
 
-    if (participant == "B") {
+    if (participant == "B")
+    {
       interface.readBlockScalarData(dataID, mesh.data.size(), vertexIDs.data(), mesh.data.data());
       VLOG(1) << "Data read: " << mesh.previewData();
     }
@@ -189,30 +210,35 @@ int main(int argc, char* argv[])
   }
 
   interface.finalize();
-    
+
   // Write out results in same format as data was read
-  if (participant == "B") {
+  if (participant == "B")
+  {
     auto meshName = aste::BaseName{options["output"].as<std::string>()}.with(context);
     auto filename = fs::path(meshName.filename());
-    if (context.rank == 0 && fs::exists(filename)) {
-      if (context.isParallel()) {
+    if (context.rank == 0 && fs::exists(filename))
+    {
+      if (context.isParallel())
+      {
         // Remove the directory <meshName>/<rank>.txt
         auto dir = filename.parent_path();
-        if (!dir.empty()) {
+        if (!dir.empty())
+        {
           fs::remove_all(dir);
           fs::create_directory(dir);
         }
-      } else {
+      }
+      else
+      {
         // Remove the mesh file <meshName>.txt
         fs::remove(filename);
       }
     }
     MPI_Barrier(MPI_COMM_WORLD);
-        
+
     VLOG(1) << "Writing results to " << filename;
     meshName.save(mesh);
   }
 
   MPI_Finalize();
 }
-


### PR DESCRIPTION
Support for reading VTK files directly without any intermediate mesh format.

Support for outputting VTK unstructured format (.vtk) meshes directly.

Only supports scalar data fields (will be extended).

