### PR TITLE
Make tests working from any directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,5 +82,5 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/mesh.py                DESTINATION ${C
 
 enable_testing()
 
-add_test(read_write_test testing)
+add_test(NAME read_write_test  COMMAND testing WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/src/tests")
 

--- a/src/tests/testing.cpp
+++ b/src/tests/testing.cpp
@@ -6,17 +6,17 @@ BOOST_AUTO_TEST_SUITE(read_write_tests)
 
 BOOST_AUTO_TEST_CASE(read_test_scalar)
 {
-  readtest(Case{"../src/tests/reference_scalars", "Scalars", 1});
+  readtest(Case{"./reference_scalars", "Scalars", 1});
 }
 
 BOOST_AUTO_TEST_CASE(read_test_2dvector)
 {
-  readtest(Case{"../src/tests/reference_vector2d", "Vector2D", 2});
+  readtest(Case{"./reference_vector2d", "Vector2D", 2});
 }
 
 BOOST_AUTO_TEST_CASE(read_test_3dvector)
 {
-  readtest(Case{"../src/tests/reference_vector3d", "Vector3D", 3});
+  readtest(Case{"./reference_vector3d", "Vector3D", 3});
 }
 
 BOOST_AUTO_TEST_CASE(write_test_scalar)


### PR DESCRIPTION
Before that setup test only work from the build directory now run from any directory if it is not installed to build