### PR TITLE
Support for vtu input/output and corrections of python scripts

### DIFF
--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -46,12 +46,13 @@ public:
   void save(const Mesh &mesh, const std::string &dataname) const;
 
 private:
-  MeshName(std::string meshname)
-      : _mname(std::move(meshname)) {}
+  MeshName(std::string meshname, const ExecutionContext &context)
+      : _mname(std::move(meshname)), _context(context) {}
 
   void createDirectories() const;
 
-  std::string _mname;
+  std::string            _mname;
+  const ExecutionContext _context;
 
   friend BaseName;
 };

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -279,18 +279,18 @@ def apply_partition(orig_mesh, part, numparts):
     return meshes, recoveryInfo
 
 
-def write_meshes(meshes, recoveryInfo, dirname):
+def write_meshes(meshes, recoveryInfo, meshname):
     """
     Writes meshes to given directory.
     """
-    dirname = os.path.abspath(dirname)
+    dirname = os.path.abspath(meshname)
     recoveryName = os.path.join(dirname, 'recovery.json')
     if os.path.exists(dirname):
         shutil.rmtree(dirname)
     os.mkdir(dirname)
     for i in range(len(meshes)):
         mesh = meshes[i]
-        mesh_io.write_txt(dirname + "/" + str(i), mesh.points, mesh.cells, mesh.pointdata)
+        mesh_io.write_vtk(dirname + "/" + meshname + "_r"+  str(i) + ".vtu", mesh.points, mesh.cells, mesh.cell_types, mesh.pointdata)
     json.dump(recoveryInfo, open(recoveryName, "w"))
         
 def parse_args():


### PR DESCRIPTION
This merge request consists of the following things:

- All the parallel cases read from `.vtu` files and write back to `.vtu` file but there is no master file is created.
- `mesh_io.py` now supports quad types also old text-based input-output is removed. Even though the output is specified as `.vtu` the output files are still in legacy format. I cannot understand why there exists a separate function to write datasets?
- `partititon_mesh.py` is working with correct context output is obeys to new preCICE/aste convention. Just after partitioning there is a gap created between two ranks it that expected behavior?
