### PR TITLE
Update VTK Calc

### DIFF
--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -11,16 +11,15 @@ import numpy as np
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("in_meshname", metavar="inputmesh", help="The mesh used as input")
-    parser.add_argument("function",
-                        help="""The function to evalutate on the mesh.
-            Syntax is the same as used in the calculator object, coordinates are given as e.g. 'coordsX+coordsY'.""")
+    parser.add_argument("in_meshname", metavar="inputmesh", help="The mesh (VTK Unstructured Grid) used as input")
+    parser.add_argument("function", help="""The function to evalutate on the mesh.
+            Syntax is the same as used in the calculator object, coordinates are given as e.g.  'cos(x)+y'.""")
     parser.add_argument("--out", "-o", dest="out_meshname", default=None, help="""The output meshname.
             Default is the same as for the input mesh""")
     parser.add_argument("--tag", "-t", dest="tag", default="MyScalar", help="""The tag for output data.
             Default is MyScalar""")
     parser.add_argument("--intag", "-it", dest="intag", help="""The tag for input data.
-            Required for diff mod""")      
+            Used in diff mode. If not given tag is used.""")
     parser.add_argument("--log", "-l", dest="logging", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="""Set the log level.
             Default is INFO""")

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -89,7 +89,7 @@ def main():
         logging.info("90th percentile of error per vertex {}".format(p90))
 
         if args.stats:
-            base = os.path.splitext(out_meshname)[0]
+            stat_file = os.path.splitext(out_meshname)[0] + ".stats.json"
             json.dump({
                 "count": cnt,
                 "min": min,
@@ -99,7 +99,7 @@ def main():
                 "99th percentile": p99,
                 "95th percentile": p95,
                 "90th percentile": p90
-            }, open(base + ".stats.json", "w"))
+            }, open(stat_file, "w"))
 
     if os.path.splitext(out_meshname) == ".vtk":
     writer = vtk.vtkUnstructuredGridWriter()

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -17,8 +17,10 @@ def parse_args():
             Syntax is the same as used in the calculator object, coordinates are given as e.g. 'coordsX+coordsY'.""")
     parser.add_argument("--out", "-o", dest="out_meshname", default=None, help="""The output meshname.
             Default is the same as for the input mesh""")
-    parser.add_argument("--tag", "-t", dest="tag", default="MyScalar", help="""The tag for data.
+    parser.add_argument("--tag", "-t", dest="tag", default="MyScalar", help="""The tag for output data.
             Default is MyScalar""")
+    parser.add_argument("--intag", "-it", dest="intag", help="""The tag for input data.
+            Required for diff mod""")      
     parser.add_argument("--log", "-l", dest="logging", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="""Set the log level.
             Default is INFO""")
@@ -46,37 +48,23 @@ def main():
     vtk_dataset = reader.GetOutput()
     logging.info("Read in {} points.".format(vtk_dataset.GetNumberOfPoints()))
 
-    if not args.diff:
-        calc = vtk.vtkArrayCalculator()
-        calc.SetInputData(vtk_dataset)
-        calc.AddCoordinateScalarVariable("coordsX", 0)
-        calc.AddCoordinateScalarVariable("coordsY", 1)
-        calc.AddCoordinateScalarVariable("coordsZ", 2)
-        calc.SetFunction(args.function)
-        calc.SetResultArrayName(args.tag)
-        calc.Update()
-
-        logging.info("Evaluated '{}' on the mesh.".format(args.function))
-        writer = vtk.vtkUnstructuredGridWriter()
-        writer.SetInputData(calc.GetOutput())
-        writer.SetFileName(out_meshname)
-        writer.Write()
-        logging.info("Written output to {}.".format(out_meshname))
-
+    calc = vtk.vtkArrayCalculator()
+    calc.SetInputData(vtk_dataset)
+    calc.AddCoordinateScalarVariable("coordsX", 0)
+    calc.AddCoordinateScalarVariable("coordsY", 1)
+    calc.AddCoordinateScalarVariable("coordsZ", 2)
+    calc.SetFunction(args.function)
+    calc.SetResultArrayName(args.tag)
+    calc.Update()    
+    logging.info("Evaluated '{}' on the mesh.".format(args.function))
+    
     if args.diff:
-        diff_calc = vtk.vtkArrayCalculator()
-        diff_calc.SetInputData(vtk_dataset)
-        diff_calc.AddCoordinateScalarVariable("coordsX", 0)
-        diff_calc.AddCoordinateScalarVariable("coordsY", 1)
-        diff_calc.AddCoordinateScalarVariable("coordsZ", 2)
-        diff_calc.SetFunction(args.function)
-        diff_calc.SetResultArrayName("Calculated Value")
-        diff_calc.Update()
+        assert args.intag is not None, "Difference mode needs input array tag"
 
         org_val = []
         calc_val = []
-        orgArr = diff_calc.GetOutput().GetPointData().GetAbstractArray(args.tag)
-        calcArr = diff_calc.GetOutput().GetPointData().GetAbstractArray("Calculated Value")
+        orgArr = calc.GetOutput().GetPointData().GetAbstractArray(args.intag)
+        calcArr = calc.GetOutput().GetPointData().GetAbstractArray(args.tag)
         num_points = vtk_dataset.GetNumberOfPoints()
         for i in range(num_points):
             org_val.append(orgArr.GetTuple1(i))
@@ -108,6 +96,11 @@ def main():
                 "90th percentile": p90
             }, open(base + ".stats.json", "w"))
 
+    writer = vtk.vtkUnstructuredGridWriter()
+    writer.SetInputData(calc.GetOutput())
+    writer.SetFileName(out_meshname)
+    writer.Write()
+    logging.info("Written output to {}.".format(out_meshname))
 
 if __name__ == "__main__":
     main()

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -1,6 +1,32 @@
 #!/usr/bin/env python3
 """Evaluates a function on a given mesh, using the VTK Calculator."""
 
+"""
+This calculator can calculate vector or scalar field on given mesh.
+
+Example usage 
+
+Scalar calculation and writing to given file
+
+./vtk_calculator.py inputmesh.vtk exp(cos(x)+sin(y)) -t e^(cos(x)+sin(y)) -o outputmesh.vtk
+
+Vector field and appends to input mesh
+
+./vtk_calculator.py inputmesh.vtk x*iHat+cos(y)*jHat-sin(z)*kHat -t MyVectorField 
+
+There is also a diff mode which provides statistic between input data and function calculated
+(Note that it only works for scalar data)
+
+./vtk_calculator.py inputmesh.vtu x+y -t mydata --diff --stats 
+
+Calculates difference between given function and mydata data save over rides into variable tag and saves statistics
+
+./vtk_calculator.py inputmesh.vtu x+y -t diffence -it mydata --diff
+
+Calculates difference between given function and mydata data save into diffence tag
+
+"""
+
 import argparse
 import logging
 import os.path

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -99,7 +99,13 @@ def main():
                 "90th percentile": p90
             }, open(base + ".stats.json", "w"))
 
+    if os.path.splitext(out_meshname) == ".vtk":
     writer = vtk.vtkUnstructuredGridWriter()
+    elif os.path.splitext(out_meshname) == ".vtu":
+        writer = vtk.vtkXMLUnstructuredGridWriter()
+    else:
+        raise Exception("Output mesh extension should be '.vtk' and '.vtu'")
+
     writer.SetInputData(calc.GetOutput())
     writer.SetFileName(out_meshname)
     writer.Write()

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -78,6 +78,7 @@ def main():
         difference = np.abs(org_val - calc_val)
         cnt, min, max = num_points, np.nanmin(difference), np.nanmax(difference)
         p99, p95, p90, median = np.percentile(difference, [99, 95, 90, 50])
+        relative = np.sqrt(np.nansum(np.square(difference)) / difference.size)
 
         logging.info("Vertex count {}".format(cnt))
         logging.info("Maximum error per vertex {}".format(max))
@@ -94,6 +95,7 @@ def main():
                 "min": min,
                 "max": max,
                 "median": median,
+                "relative-l2": relative,
                 "99th percentile": p99,
                 "95th percentile": p95,
                 "90th percentile": p90

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -57,8 +57,8 @@ def main():
     calc.AddCoordinateScalarVariable("y", 1)
     calc.AddCoordinateScalarVariable("z", 2)
     if args.diff:
-        calc.SetFunction('abs({}-{})'.format(intag, args.function))
-        logging.info("Evaluated 'abs({}-{})' on the mesh.".format(intag, args.function))
+        calc.SetFunction('{}-({})'.format(intag, args.function))
+        logging.info("Evaluated '{}-({})' on the mesh.".format(intag, args.function))
     else:
         calc.SetFunction(args.function)
         logging.info("Evaluated '{}' on the mesh.".format(args.function))

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -39,6 +39,7 @@ def main():
 
     out_meshname = args.out_meshname
     if args.out_meshname is None:
+        logging.info("No output mesh name is given {} will be used.".format(args.in_meshname))
         out_meshname = args.in_meshname
 
     if args.diff and args.intag is None:
@@ -49,7 +50,7 @@ def main():
     reader.SetFileName(args.in_meshname)
     reader.Update()
     vtk_dataset = reader.GetOutput()
-    logging.info("Read in {} points.".format(vtk_dataset.GetNumberOfPoints()))
+    logging.info("Mesh contains {} points.".format(vtk_dataset.GetNumberOfPoints()))
 
     calc = vtk.vtkArrayCalculator()
     calc.SetInputData(vtk_dataset)
@@ -81,6 +82,7 @@ def main():
         relative = np.sqrt(np.nansum(np.square(difference)) / difference.size)
 
         logging.info("Vertex count {}".format(cnt))
+        logging.info("Relative l2 error {}".format(relative))
         logging.info("Maximum error per vertex {}".format(max))
         logging.info("Minimum error per vertex {}".format(min))
         logging.info("Median error per vertex {}".format(median))
@@ -90,6 +92,7 @@ def main():
 
         if args.stats:
             stat_file = os.path.splitext(out_meshname)[0] + ".stats.json"
+            logging.info("Saving stats data to {}".format(stat_file))
             json.dump({
                 "count": cnt,
                 "min": min,

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -53,9 +53,9 @@ def main():
 
     calc = vtk.vtkArrayCalculator()
     calc.SetInputData(vtk_dataset)
-    calc.AddCoordinateScalarVariable("coordsX", 0)
-    calc.AddCoordinateScalarVariable("coordsY", 1)
-    calc.AddCoordinateScalarVariable("coordsZ", 2)
+    calc.AddCoordinateScalarVariable("x", 0)
+    calc.AddCoordinateScalarVariable("y", 1)
+    calc.AddCoordinateScalarVariable("z", 2)
     calc.SetFunction(args.function)
     calc.SetResultArrayName(args.tag)
     calc.Update()    

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -27,7 +27,6 @@ def parse_args():
     parser.add_argument("--stats", "-s", action='store_true',
                         help="Store stats of the difference calculation as the separate file inputmesh.stats.json")
     args = parser.parse_args()
-    args.out_meshname = args.out_meshname or args.in_meshname
     return args
 
 
@@ -105,9 +104,9 @@ def main():
                 "90th percentile": p90
             }, open(stat_file, "w"))
 
-    if os.path.splitext(out_meshname) == ".vtk":
+    if os.path.splitext(out_meshname)[1] == ".vtk":
         writer = vtk.vtkUnstructuredGridWriter()
-    elif os.path.splitext(out_meshname) == ".vtu":
+    elif os.path.splitext(out_meshname)[1] == ".vtu":
         writer = vtk.vtkXMLUnstructuredGridWriter()
     else:
         raise Exception("Output mesh extension should be '.vtk' and '.vtu'")

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -41,6 +41,10 @@ def main():
     if args.out_meshname is None:
         out_meshname = args.in_meshname
 
+    if args.diff and args.intag is None:
+        logging.info("No intag is given outtag '{}' will be used as intag.".format(args.tag))
+        intag = args.tag
+
     reader = vtk.vtkGenericDataObjectReader()
     reader.SetFileName(args.in_meshname)
     reader.Update()


### PR DESCRIPTION
This update is related to Issue #36 

The previous script `eval_mesh` highly depended on `mesh_io` this update to VTK Calculator makes it a standalone script and provides missing functionalities. Which will replaces `eval_mesh`

In normal mode, it calculates function `f : (R³) -> R` and append to mesh file.
Example usage 

`./vtk_calculator.py bunny.vtk 'coordsX+coordsY'  -t "x+y" ` -> Calculates function `f=x+y` on mesh and save with datanamed `x+y`

In diff mode, it calculates function and compares with given data array.

 `./vtk_calculator.py bunny.vtk '2*coordsX+2*coordsY'  -t "2x+2y" -d -s -it "x+y"` -> Calculates function `f=2x+2y` on mesh compares with datanamed `x+y` prints report and save json file. Appends calculated funciton `2x+2y` to mesh.






