### PR TITLE
Fix Join Mesh

### DIFF
--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -27,7 +27,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
     parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input")
     parser.add_argument("--out", "-o", dest="out_meshname", help="The output mesh. Can be vtk or vtu.")
-    parser.add_argument("-r", "--recovery", dest="recovery", help="The path to recovery file to fully recover it's state.")
+    parser.add_argument("-r", "--recovery", dest="recovery", help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,
             help="The number of parts to read from the input mesh. By default the entire mesh is read.")
     parser.add_argument("--log", "-l", dest="logging", default="INFO",

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -127,7 +127,7 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
     """
     Partition merge with full recovery
 
-    This saves original mesh.
+    This recovers the original mesh.
     """
     logging.info("Starting full mesh recovery")
     recoveryFile = os.path.join(recoveryPath, "recovery.json")

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Joins meshes partitioned by ASTE mesh partitioner.
+Joins meshes partitioned by the ASTE mesh partitioner.
 
 There is two possible way of merging:
 - Partition-wise (does not recovery original mesh order and lack of discarded cells)

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -25,8 +25,8 @@ import vtk
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
-    parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input")
-    parser.add_argument("--out", "-o", dest="out_meshname", help="The output mesh. Can be vtk or vtu.")
+    parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input (only VTU format is accepted)")
+    parser.add_argument("--out", "-o", dest="out_meshname", help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
     parser.add_argument("-r", "--recovery", dest="recovery", help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,
             help="The number of parts to read from the input mesh. By default the entire mesh is read.")

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -2,8 +2,8 @@
 """
 Joins meshes partitioned by the ASTE mesh partitioner.
 
-There is two possible way of merging:
-- Partition-wise (does not recovery original mesh order and lack of discarded cells)
+There are two possible ways of joining the meshes:
+- Partition-wise (does not recover the original mesh order lacks of discarded cells)
 - Recovery merge (maintain original mesh order and adds discarded cells)
 
 Sample usage 

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -25,7 +25,7 @@ import vtk
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
-    parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input (only VTU format is accepted)")
+    parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
     parser.add_argument("--out", "-o", dest="out_meshname", help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
     parser.add_argument("-r", "--recovery", dest="recovery", help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,


### PR DESCRIPTION
This is almost a total replacement to the old mesh joiner.
Reads `vtu` files and join into a `vtu` or `vtk` file.
If recovery file is given preserves original mesh order and cells else appends partition-wise.
Supports all vector and scalar data preserve all of them
Closes [#35 ](https://github.com/precice/aste/issues/35)