### PR TITLE
Fix bug intag is not used if it is given

### DIFF
--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -70,6 +70,8 @@ def main():
     if args.diff and args.intag is None:
         logging.info("No intag is given outtag '{}' will be used as intag.".format(args.tag))
         intag = args.tag
+    else:
+        intag = args.intag
 
     reader = vtk.vtkGenericDataObjectReader()
     reader.SetFileName(args.in_meshname)


### PR DESCRIPTION
There was a bug in `vtk_calculator`

If `intag` is given it is not used in diff mode. 

It is fixed by this PR.