### PR TITLE
Fix missing data after mapping 

### DIFF
--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -86,6 +86,7 @@ struct Mesh {
   std::vector<Triangle> triangles;
   std::vector<Quad>     quadrilaterals;
   std::vector<double>   data;
+  std::string           fname;
 
   std::string previewData(std::size_t max = 10) const;
   std::string summary() const;

--- a/src/tests/read_test.cpp
+++ b/src/tests/read_test.cpp
@@ -1,6 +1,6 @@
 #include "testing.hpp"
 
-void readtest(const Case &current_case)
+void readtest(const ReadCase &current_case)
 {
 
   auto read_test = aste::BaseName{current_case.fname}.with(aste::ExecutionContext());

--- a/src/tests/testing.cpp
+++ b/src/tests/testing.cpp
@@ -6,32 +6,32 @@ BOOST_AUTO_TEST_SUITE(read_write_tests)
 
 BOOST_AUTO_TEST_CASE(read_test_scalar)
 {
-  readtest(Case{"./reference_scalars", "Scalars", 1});
+  readtest(ReadCase{"./reference_scalars", "Scalars", 1});
 }
 
 BOOST_AUTO_TEST_CASE(read_test_2dvector)
 {
-  readtest(Case{"./reference_vector2d", "Vector2D", 2});
+  readtest(ReadCase{"./reference_vector2d", "Vector2D", 2});
 }
 
 BOOST_AUTO_TEST_CASE(read_test_3dvector)
 {
-  readtest(Case{"./reference_vector3d", "Vector3D", 3});
+  readtest(ReadCase{"./reference_vector3d", "Vector3D", 3});
 }
 
 BOOST_AUTO_TEST_CASE(write_test_scalar)
 {
-  writetest(Case{"./scalar_write", "Scalars", 1});
+  writetest(WriteCase{"./reference_scalars", "./scalar_write", "Scalars", 1});
 }
 
 BOOST_AUTO_TEST_CASE(write_test_2dvector)
 {
-  writetest(Case{"./vector2d_write", "Vector2D", 2});
+  writetest(WriteCase{"./reference_vector2d", "./vector2d_write", "Vector2D", 2});
 }
 
 BOOST_AUTO_TEST_CASE(write_test_3dvector)
 {
-  writetest(Case{"./vector3d_write", "Vector3D", 3});
+  writetest(WriteCase{"./reference_vector3d", "./vector3d_write", "Vector3D", 3});
 }
 
 BOOST_AUTO_TEST_SUITE_END() //read_write_tests

--- a/src/tests/testing.hpp
+++ b/src/tests/testing.hpp
@@ -3,11 +3,18 @@
 #include <numeric>
 #include <string>
 
-struct Case {
+struct ReadCase {
   std::string fname{};
   std::string dataname{};
   int         dim{};
 };
 
-void writetest(const Case &current_case);
-void readtest(const Case &current_case);
+struct WriteCase {
+  std::string basename{};
+  std::string fname{};
+  std::string dataname{};
+  int         dim{};
+};
+
+void writetest(const WriteCase &current_case);
+void readtest(const ReadCase &current_case);

--- a/src/tests/write_test.cpp
+++ b/src/tests/write_test.cpp
@@ -1,49 +1,22 @@
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <cstdlib>
+
 #include "testing.hpp"
 
-void writetest(const Case &current_case)
+namespace fs = boost::filesystem;
+
+void writetest(const WriteCase &current_case)
 {
-  using VID = aste::Mesh::VID;
 
-  aste::Mesh testMesh;
-  testMesh.positions.reserve(12);
+  auto write_test = aste::BaseName{current_case.basename}.with(aste::ExecutionContext());
+  auto testMesh   = write_test.load(current_case.dim, current_case.dataname);
 
-  // Points for Quads and Tri Elements
-  for (double y = 0; y < 3.0; ++y) {
-    for (double x = 0; x < 3.0; ++x) {
-      const std::array<double, 3> pos{x, y, 0.0};
-      testMesh.positions.push_back(pos);
-    }
-  }
-  //Points for Line Elements
-  for (double x = 4; x < 7.0; ++x) {
-    const std::array<double, 3> pos{x, 0.0, 0.0};
-    testMesh.positions.push_back(pos);
-  }
-
-  //Create Lines
-  std::array<VID, 2> line1{9, 10};
-  std::array<VID, 2> line2{10, 11};
-  testMesh.edges.push_back(line1);
-  testMesh.edges.push_back(line2);
-
-  // Create Triangles
-  std::array<VID, 3> tri1{0, 1, 3};
-  std::array<VID, 3> tri2{1, 4, 3};
-  std::array<VID, 3> tri3{1, 2, 4};
-  std::array<VID, 3> tri4{2, 4, 5};
-  testMesh.triangles.push_back(tri1);
-  testMesh.triangles.push_back(tri2);
-  testMesh.triangles.push_back(tri3);
-  testMesh.triangles.push_back(tri4);
-
-  //Create Quad Elements
-  std::array<VID, 4> quad1{3, 4, 7, 6};
-  std::array<VID, 4> quad2{4, 5, 8, 7};
-  testMesh.quadrilaterals.push_back(quad1);
-  testMesh.quadrilaterals.push_back(quad2);
-
+  // Create a new data (mapped) and changeg with old one
+  // Use random starting point for a series of data
   testMesh.data.resize(testMesh.positions.size() * current_case.dim);
-  std::iota(testMesh.data.begin(), testMesh.data.end(), 0);
+  std::iota(testMesh.data.begin(), testMesh.data.end(), rand());
+
   auto scalar_test = aste::BaseName{current_case.fname}.with(aste::ExecutionContext());
   scalar_test.save(testMesh, current_case.dataname);
 
@@ -73,5 +46,11 @@ void writetest(const Case &current_case)
   //Check Data Values
   for (size_t i = 0; i < loadedMesh.data.size(); ++i) {
     BOOST_TEST(loadedMesh.data[i] == testMesh.data[i]);
+  }
+
+  //Remove Artifacts
+  std::cout << current_case.fname << std::endl;
+  if (fs::is_regular_file(current_case.fname + ".vtk")) {
+    fs::remove(current_case.fname + ".vtk");
   }
 }


### PR DESCRIPTION
After the mapping process using `preciceMap` except mapped data all of the datasets were not transferred to the output mesh.

In this fix, the input mesh file is used as a base for output mesh and only mapped data will be added to the input mesh. All other datasets will be preserved in this way.


