### PR TITLE
Satisfy Consistency in CLI

### DIFF
--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -11,9 +11,9 @@ Sample usage
 partitioned files:
 prefix_<#>.vtu
 
-./join_mesh.py prefix -o joined_mesh.vtk
+./join_mesh.py -m prefix -o joined_mesh.vtk -dir joined_mesh_dir
 
-./join_mesh.py prefix -o joined_mesh.vtk -r ./path/to/recovery.json
+./join_mesh.py -m prefix -o joined_mesh.vtk -r ./path/to/recovery.json
 
 """
 
@@ -26,10 +26,12 @@ import vtk
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
-    parser.add_argument("--mesh", "-m", dest="in_meshname", 
-    help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
-    parser.add_argument("--output", "-o", dest="out_meshname", 
-    help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
+    parser.add_argument("--mesh", "-m", required=True, dest="in_meshname",
+                        help="""The partitioned mesh prefix used as input (only VTU format is accepted)
+    (Looking for <prefix>_<#filerank>.vtu) """)
+    parser.add_argument("--output", "-o", dest="out_meshname",
+                        help="""The output mesh. Can be VTK or VTU format.
+                        If it is not given <inputmesh>_joined.vtk will be used.""")
     parser.add_argument("-r", "--recovery", dest="recovery",
                         help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -13,7 +13,7 @@ prefix_<#>.vtu
 
 ./join_mesh.py prefix -o joined_mesh.vtk
 
-./join_mesh.py prefix -o joined_mesh.vtk -r ./recovery/path/
+./join_mesh.py prefix -o joined_mesh.vtk -r ./path/to/recovery.json
 
 """
 
@@ -25,8 +25,8 @@ import vtk
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
-    parser.add_argument("in_meshname", metavar="inputmesh", help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
-    parser.add_argument("--out", "-o", dest="out_meshname", help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
+    parser.add_argument("--mesh" ,"-m",dest="in_meshname", help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
+    parser.add_argument("--output", "-o", dest="out_meshname", help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
     parser.add_argument("-r", "--recovery", dest="recovery", help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,
             help="The number of parts to read from the input mesh. By default the entire mesh is read.")
@@ -132,8 +132,7 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
     This recovers the original mesh.
     """
     logging.info("Starting full mesh recovery")
-    recoveryFile = os.path.join(recoveryPath, "recovery.json")
-    recovery = json.load(open(recoveryFile, "r"))
+    recovery = json.load(open(recoveryPath, "r"))
     cells = recovery["cells"]
     size = recovery["size"]
     cell_types = recovery["cell_types"]

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -6,7 +6,7 @@ There are two possible ways of joining the meshes:
 - Partition-wise (does not recover the original mesh order lacks of discarded cells)
 - Recovery merge (maintain original mesh order and adds discarded cells)
 
-Sample usage 
+Sample usage
 
 partitioned files:
 prefix_<#>.vtu
@@ -23,31 +23,40 @@ import os
 import json
 import vtk
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Read a partitioned mesh and join it into a .vtk or .vtu file.")
-    parser.add_argument("--mesh" ,"-m",dest="in_meshname", help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
-    parser.add_argument("--output", "-o", dest="out_meshname", help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
-    parser.add_argument("-r", "--recovery", dest="recovery", help="The path to the recovery file to fully recover it's state.")
+    parser.add_argument("--mesh", "-m", dest="in_meshname", 
+    help="The partitioned mesh prefix used as input (only VTU format is accepted) (Looking for <prefix>_<#filerank>.vtu) ")
+    parser.add_argument("--output", "-o", dest="out_meshname", 
+    help="The output mesh. Can be VTK or VTU format. If it is not given <inputmesh>_joined.vtk will be used.")
+    parser.add_argument("-r", "--recovery", dest="recovery",
+                        help="The path to the recovery file to fully recover it's state.")
     parser.add_argument("--numparts", "-n", dest="numparts", type=int,
-            help="The number of parts to read from the input mesh. By default the entire mesh is read.")
+                        help="The number of parts to read from the input mesh. By default the entire mesh is read.")
+    parser.add_argument("--directory", "-dir", dest="directory", default=None,
+                        help="Directory for output files (optional)")
     parser.add_argument("--log", "-l", dest="logging", default="INFO",
-            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="Set the log level. Default is INFO")
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                        help="Set the log level. Default is INFO")
     return parser.parse_args()
+
 
 def main():
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.logging))
     out_meshname = args.out_meshname if args.out_meshname else args.in_meshname + "_joined.vtk"
     joined_mesh = read_meshes(args.in_meshname, args.numparts, args.recovery)
-    write_mesh(joined_mesh,out_meshname)
+    write_mesh(joined_mesh, out_meshname, args.directory)
 
-def read_meshes(prefix : str, partitions = None, recoveryPath = None):
+
+def read_meshes(prefix: str, partitions=None, recoveryPath=None):
     """
     Reads meshes with given prefix.
     """
     if not partitions:
         partitions = count_partitions(prefix)
-        logging.debug("Detected "+str(partitions)+" partitions with prefix "+ prefix)
+        logging.debug("Detected " + str(partitions) + " partitions with prefix " + prefix)
     if partitions == 0:
         raise Exception("No partitions found")
 
@@ -58,13 +67,14 @@ def read_meshes(prefix : str, partitions = None, recoveryPath = None):
         logging.info("Recovery data found. Full recovery will be executed")
         return join_mesh_recovery(prefix, partitions, recoveryPath)
 
-def join_mesh_partitionwise(prefix : str, partitions : int):
+
+def join_mesh_partitionwise(prefix: str, partitions: int):
     """
-    Partition-wise load and append. 
+    Partition-wise load and append.
     Does not recover missing cells.
     Cells and points may be scrambled wrt original mesh.
     """
-    
+
     logging.info("Starting partition-wise mesh merge")
     joined_mesh = vtk.vtkUnstructuredGrid()
     joined_points = vtk.vtkPoints()
@@ -80,28 +90,27 @@ def join_mesh_partitionwise(prefix : str, partitions : int):
         reader.Update()
         part_mesh = reader.GetOutput()
 
-        logging.debug("File {} contains {} points".format(fname,part_mesh.GetNumberOfPoints()))
+        logging.debug("File {} contains {} points".format(fname, part_mesh.GetNumberOfPoints()))
         for i in range(part_mesh.GetNumberOfPoints()):
             joined_points.InsertNextPoint(part_mesh.GetPoint(i))
-        
+
         part_point_data = part_mesh.GetPointData()
         num_arrays = part_point_data.GetNumberOfArrays()
-        
+
         if joined_data_arrays is None:
             joined_data_arrays = []
             for j in range(num_arrays):
                 newArr = vtk.vtkDoubleArray()
                 newArr.SetName(part_point_data.GetArrayName(j))
                 joined_data_arrays.append(newArr)
-        
-        
+
         for j in range(num_arrays):
             array_name = part_point_data.GetArrayName(j)
-            logging.debug("Merging from file {} dataname {}".format(fname,array_name))
+            logging.debug("Merging from file {} dataname {}".format(fname, array_name))
             array_data = part_point_data.GetArray(array_name)
             join_arr = joined_data_arrays[j]
             join_arr.SetNumberOfComponents(array_data.GetNumberOfComponents())
-            join_arr.InsertTuples(join_arr.GetNumberOfTuples(),array_data.GetNumberOfTuples(),0,array_data)
+            join_arr.InsertTuples(join_arr.GetNumberOfTuples(), array_data.GetNumberOfTuples(), 0, array_data)
 
         for i in range(part_mesh.GetNumberOfCells()):
             cell = part_mesh.GetCell(i)
@@ -109,23 +118,23 @@ def join_mesh_partitionwise(prefix : str, partitions : int):
             vtkCell.SetCellType(cell.GetCellType())
             idList = vtk.vtkIdList()
             for j in range(cell.GetNumberOfPoints()):
-                idList.InsertNextId(cell.GetPointId(j)+ offset)
+                idList.InsertNextId(cell.GetPointId(j) + offset)
             vtkCell.SetPointIds(idList)
             joined_cell_types.append(cell.GetCellType())
             joined_cells.InsertNextCell(vtkCell)
 
         offset += part_mesh.GetNumberOfPoints()
-    
+
     if len(joined_cell_types) != 0:
-        joined_mesh.SetCells(joined_cell_types,joined_cells)
+        joined_mesh.SetCells(joined_cell_types, joined_cells)
     joined_mesh.SetPoints(joined_points)
     for data_array in joined_data_arrays:
         joined_mesh.GetPointData().AddArray(data_array)
-            
+
     return joined_mesh
 
 
-def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
+def join_mesh_recovery(prefix: str, partitions: int, recoveryPath: str):
     """
     Partition merge with full recovery
 
@@ -149,7 +158,7 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
     joined_cell_types = []
 
     for i in range(partitions):
-        global_ids= [] 
+        global_ids = []
 
         fname = prefix + "_" + str(i) + ".vtu"
         reader = vtk.vtkXMLUnstructuredGridReader()
@@ -159,38 +168,38 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
         part_point_data = part_mesh.GetPointData()
         num_arrays = part_point_data.GetNumberOfArrays()
 
-        #Prepare DataArrays
+        # Prepare DataArrays
         if joined_data_arrays is None:
             joined_data_arrays = []
             for j in range(num_arrays):
                 newArr = vtk.vtkDoubleArray()
                 newArr.SetName(part_point_data.GetArrayName(j))
                 newArr.SetNumberOfTuples(size)
-                joined_data_arrays.append(newArr)        
+                joined_data_arrays.append(newArr)
 
         # Extract Global IDs
         array_data = part_point_data.GetArray("GlobalIDs")
         # Check if GlobalIDs exist if not do partition-wise merge
         if array_data is None:
             logging.warning("GlobalIDs were not found, a recovery merge is not possible.")
-            return join_mesh_partitionwise(prefix,partitions)
+            return join_mesh_partitionwise(prefix, partitions)
 
         for k in range(array_data.GetNumberOfTuples()):
             global_ids.append(array_data.GetTuple(k))
-        logging.debug("File {} contains {} points".format(fname,part_mesh.GetNumberOfPoints()))
+        logging.debug("File {} contains {} points".format(fname, part_mesh.GetNumberOfPoints()))
         for i in range(part_mesh.GetNumberOfPoints()):
-            joined_points.SetPoint(int(global_ids[i][0]),part_mesh.GetPoint(i))    
-        
+            joined_points.SetPoint(int(global_ids[i][0]), part_mesh.GetPoint(i))
+
         # Append Point Data to Original Locations
         for j in range(num_arrays):
             array_name = part_point_data.GetArrayName(j)
-            logging.debug("Merging from file {} dataname {}".format(fname,array_name))
+            logging.debug("Merging from file {} dataname {}".format(fname, array_name))
             array_data = part_point_data.GetArray(array_name)
             join_arr = joined_data_arrays[j]
             join_arr.SetNumberOfComponents(array_data.GetNumberOfComponents())
             join_arr.SetNumberOfTuples(size)
             for k in range(array_data.GetNumberOfTuples()):
-                join_arr.SetTuple(int(global_ids[k][0]),array_data.GetTuple(k))
+                join_arr.SetTuple(int(global_ids[k][0]), array_data.GetTuple(k))
 
         # Append Cells
         for i in range(part_mesh.GetNumberOfCells()):
@@ -203,9 +212,9 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
             vtkCell.SetPointIds(idList)
             joined_cell_types.append(cell.GetCellType())
             joined_cells.InsertNextCell(vtkCell)
-    
+
     # Append Recovery Cells
-        for cell, cell_type in zip(cells,cell_types):
+        for cell, cell_type in zip(cells, cell_types):
             vtkCell = vtk.vtkGenericCell()
             vtkCell.SetCellType(cell_type)
             idList = vtk.vtkIdList()
@@ -215,9 +224,9 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
             joined_cell_types.append(cell_type)
             joined_cells.InsertNextCell(vtkCell)
 
-    # Set Points, Cells, Data on Grid 
+    # Set Points, Cells, Data on Grid
     if len(joined_cell_types) != 0:
-        joined_mesh.SetCells(joined_cell_types,joined_cells)
+        joined_mesh.SetCells(joined_cell_types, joined_cells)
     joined_mesh.SetPoints(joined_points)
     for data_array in joined_data_arrays:
         joined_mesh.GetPointData().AddArray(data_array)
@@ -225,8 +234,7 @@ def join_mesh_recovery(prefix : str, partitions : int, recoveryPath : str):
     return joined_mesh
 
 
-
-def count_partitions(prefix : str) -> int:
+def count_partitions(prefix: str) -> int:
     """Count how many partitions available with given prefix
 
     Args:
@@ -243,7 +251,14 @@ def count_partitions(prefix : str) -> int:
         detected += 1
     return detected
 
-def write_mesh(meshfile,filename):
+
+def write_mesh(meshfile, filename, directory=None):
+
+    filename = os.path.basename(os.path.normpath(filename))
+    if directory:
+        directory = os.path.abspath(directory)
+        os.makedirs(directory, exist_ok=True)
+        filename = os.path.join(directory, filename)
 
     extension = os.path.splitext(filename)[1]
     if (extension == ".vtk"):  # VTK Legacy format
@@ -255,9 +270,6 @@ def write_mesh(meshfile,filename):
     writer.SetFileName(filename)
     writer.SetInputData(meshfile)
     writer.Write()
-
-
-
 
 
 if __name__ == "__main__":

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -30,7 +30,7 @@ def main():
             if os.path.exists(directory):
                 shutil.rmtree(directory)
             os.mkdir(directory)
-            out_meshname = directory + args.out_meshname
+            out_meshname = os.path.join(directory, args.out_meshname)
         else:
             out_meshname = args.out_meshname
         extension = os.path.splitext(mesh_name)[1]
@@ -409,8 +409,18 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
     for i in range(len(meshes)):
         mesh = meshes[i]
         if directory:
-            write_mesh(directory + mesh_prefix + "_" + str(i) + ".vtu", mesh.points, mesh.data_index, mesh.cells,
-                       mesh.cell_types, orig_mesh)
+            write_mesh(
+                os.path.join(
+                    directory,
+                    mesh_prefix) +
+                "_" +
+                str(i) +
+                ".vtu",
+                mesh.points,
+                mesh.data_index,
+                mesh.cells,
+                mesh.cell_types,
+                orig_mesh)
         else:
             write_mesh(mesh_prefix + "_" + str(i) + ".vtu", mesh.points, mesh.data_index, mesh.cells,
                        mesh.cell_types, orig_mesh)

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -416,7 +416,7 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Read meshes, partition them and write them out in VTU format.")
-    parser.add_argument("--mesh", "-m", dest="in_meshname", help="The mesh used as input")
+    parser.add_argument("--mesh", "-m", required=True, dest="in_meshname", help="The mesh used as input")
     parser.add_argument("--output", "-o", dest="out_meshname", default="partitioned_mesh",
                         help="The output mesh name.")
     parser.add_argument("--directory", "-dir", dest="directory", default=None,

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -27,9 +27,7 @@ def main():
         if args.directory:
             # Get the absolute directory where we want to store the mesh
             directory = os.path.abspath(args.directory)
-            if os.path.exists(directory):
-                shutil.rmtree(directory)
-            os.mkdir(directory)
+            os.makedirs(directory,exist_ok=True)
             out_meshname = os.path.join(directory, args.out_meshname)
         else:
             out_meshname = args.out_meshname
@@ -402,8 +400,7 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
         # Get the absolute directory where we want to store the mesh
         directory = os.path.abspath(directory)
         recoveryName = os.path.join(directory, 'recovery.json')
-        if not os.path.exists(directory):
-            os.mkdir(directory)
+        os.makedirs(directory,exist_ok=True)
 
     for i in range(len(meshes)):
         mesh = meshes[i]

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -27,7 +27,7 @@ def main():
         if args.directory:
             # Get the absolute directory where we want to store the mesh
             directory = os.path.abspath(args.directory)
-            os.makedirs(directory,exist_ok=True)
+            os.makedirs(directory, exist_ok=True)
             out_meshname = os.path.join(directory, args.out_meshname)
         else:
             out_meshname = args.out_meshname
@@ -393,14 +393,14 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
     Writes meshes to given directory.
     """
 
-    recoveryName = 'recovery.json'
+    recoveryName = os.path.basename(os.path.normpath('recovery.json'))
     # Strip off the mesh-prefix for the directory creation
     mesh_prefix = os.path.basename(os.path.normpath(meshname))
     if directory:
         # Get the absolute directory where we want to store the mesh
         directory = os.path.abspath(directory)
         recoveryName = os.path.join(directory, 'recovery.json')
-        os.makedirs(directory,exist_ok=True)
+        os.makedirs(directory, exist_ok=True)
 
     for i in range(len(meshes)):
         mesh = meshes[i]

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -402,25 +402,14 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
         # Get the absolute directory where we want to store the mesh
         directory = os.path.abspath(directory)
         recoveryName = os.path.join(directory, 'recovery.json')
-        if os.path.exists(directory):
-            shutil.rmtree(directory)
-        os.mkdir(directory)
+        if not os.path.exists(directory):
+            os.mkdir(directory)
 
     for i in range(len(meshes)):
         mesh = meshes[i]
         if directory:
-            write_mesh(
-                os.path.join(
-                    directory,
-                    mesh_prefix) +
-                "_" +
-                str(i) +
-                ".vtu",
-                mesh.points,
-                mesh.data_index,
-                mesh.cells,
-                mesh.cell_types,
-                orig_mesh)
+            write_mesh(os.path.join(directory, mesh_prefix) + "_" + str(i) + ".vtu", mesh.points, mesh.data_index,
+                       mesh.cells, mesh.cell_types, orig_mesh)
         else:
             write_mesh(mesh_prefix + "_" + str(i) + ".vtu", mesh.points, mesh.data_index, mesh.cells,
                        mesh.cell_types, orig_mesh)

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -47,7 +47,7 @@ def parse_args():
             Syntax is the same as used in the calculator object, coordinates are given as e.g.  'cos(x)+y'.""")
     parser.add_argument("--output", "-o", dest="out_meshname", default=None, help="""The output meshname.
             Default is the same as for the input mesh""")
-    parser.add_argument("--data", "-d", dest="data", required=True, default="MyData", help="""The name of output data.
+    parser.add_argument("--data", "-d", dest="data", default="MyData", help="""The name of output data.
             Default is MyData""")
     parser.add_argument("--diffdata", "-diffd", dest="diffdata", help="""The name of difference data.
             Used in diff mode. If not given, output data is used.""")

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -71,7 +71,7 @@ def main():
         out_meshname = args.in_meshname
 
     if args.diff and args.indata is None:
-        logging.info("No indata is given outdata '{}' will be used as indata.".format(args.data))
+        logging.info("No input dataname is given outdata '{}' will be used as input dataname.".format(args.data))
         indata = args.data
     else:
         indata = args.indata
@@ -96,20 +96,20 @@ def main():
     calc.AddCoordinateScalarVariable("z", 2)
     if args.diff:
         # Check VTK file has dataname
-        if not vtk_dataset.GetPointData().HasArray(intag):
+        if not vtk_dataset.GetPointData().HasArray(indata):
             logging.warning(
                 "Given mesh \"{}\" has no data with given name \"{}\".\nABORTING!\n".format(
-                    args.in_meshname, intag))
+                    args.in_meshname, indata))
             sys.exit()
         else:
-            data = v2n(vtk_dataset.GetPointData().GetAbstractArray(intag))
+            data = v2n(vtk_dataset.GetPointData().GetAbstractArray(indata))
         # Calculate given function on the mesh
         calc.SetFunction(args.function)
         calc.SetResultArrayName("function")
         calc.Update()
         func = v2n(calc.GetOutput().GetPointData().GetAbstractArray("function"))
         difference = data - func
-        logging.info("Evaluated \"{}\"-\"({})\" on the mesh \"{}\".".format(intag, args.function, args.in_meshname))
+        logging.info("Evaluated \"{}\"-\"({})\" on the mesh \"{}\".".format(indata, args.function, args.in_meshname))
 
         # Calculate Statistics
         num_points = vtk_dataset.GetNumberOfPoints()
@@ -143,9 +143,10 @@ def main():
     else:
         calc.SetFunction(args.function)
         logging.info("Evaluated \"{}\" on the input mesh \"{}\".".format(args.function, args.in_meshname))
-    calc.SetResultArrayName(args.tag)
-    calc.Update()
-    logging.info("Evaluated function saved to \"{}\" variable on output mesh \"{}\"".format(args.tag, out_meshname))
+        calc.SetResultArrayName(args.data)
+        calc.Update()
+    
+    logging.info("Evaluated function saved to \"{}\" variable on output mesh \"{}\"".format(args.data, out_meshname))
 
     if os.path.splitext(out_meshname)[1] == ".vtk":
         writer = vtk.vtkUnstructuredGridWriter()
@@ -156,7 +157,7 @@ def main():
 
     if args.diff:
         diff_vtk = n2v(difference)
-        diff_vtk.SetName(args.tag)
+        diff_vtk.SetName(args.data)
         num_comp = diff_vtk.GetNumberOfComponents()
         if num_comp > 1:
             vtk_dataset.GetPointData().SetVectors(diff_vtk)

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -40,18 +40,20 @@ from vtk.util.numpy_support import numpy_to_vtk as n2v
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mesh","-m",dest="in_meshname", help="The mesh (VTK Unstructured Grid) used as input")
-    parser.add_argument("--function","-f",dest="function", help="""The function to evalutate on the mesh.
+    parser.add_argument("--mesh", "-m", dest="in_meshname", help="The mesh (VTK Unstructured Grid) used as input")
+    parser.add_argument("--function", "-f", dest="function", help="""The function to evalutate on the mesh.
             Syntax is the same as used in the calculator object, coordinates are given as e.g.  'cos(x)+y'.""")
     parser.add_argument("--output", "-o", dest="out_meshname", default=None, help="""The output meshname.
             Default is the same as for the input mesh""")
-    parser.add_argument("--data", dest="data", default="MyData", help="""The name of output data.
+    parser.add_argument("--data", "-d", dest="data", default="MyData", help="""The name of output data.
             Default is MyData""")
-    parser.add_argument("--indata", dest="indata", help="""The name of input data.
+    parser.add_argument("--indata", "-ind", dest="indata", help="""The name of input data.
             Used in diff mode. If not given, output data is used.""")
     parser.add_argument("--log", "-l", dest="logging", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="""Set the log level.
             Default is INFO""")
+    parser.add_argument("--directory", "-dir", dest="directory", default=None,
+                        help="Directory for output files (optional)")
     parser.add_argument("--diff", action='store_true', help="Calculate the difference to present data.")
     parser.add_argument("--stats", "-s", action='store_true',
                         help="Store stats of the difference calculation as the separate file inputmesh.stats.json")
@@ -145,7 +147,7 @@ def main():
         logging.info("Evaluated \"{}\" on the input mesh \"{}\".".format(args.function, args.in_meshname))
         calc.SetResultArrayName(args.data)
         calc.Update()
-    
+
     logging.info("Evaluated function saved to \"{}\" variable on output mesh \"{}\"".format(args.data, out_meshname))
 
     if os.path.splitext(out_meshname)[1] == ".vtk":
@@ -166,6 +168,13 @@ def main():
         writer.SetInputData(vtk_dataset)
     else:
         writer.SetInputData(calc.GetOutput())
+
+    out_meshname = os.path.basename(os.path.normpath(out_meshname))
+    if args.directory:
+        directory = os.path.abspath(args.directory)
+        os.makedirs(directory, exist_ok=True)
+        out_meshname = os.path.join(directory, out_meshname)
+
     writer.SetFileName(out_meshname)
     writer.Write()
     logging.info("Written output to \"{}\".".format(out_meshname))


### PR DESCRIPTION
Solves #56 

All scripts use the same CLI input style

| Input Arg | Explanation                       |
| --------- | --------------------------------- |
| --mesh    | Input Mesh                        |
| --output  | Output Mesh                       |
| --data    | Data Modified/Calculatated/Mapped |

```bash
mpirun -n 2 preciceMap -v -p B --mesh coarse_mesh --output mapped/mapped --data "x + y"

partition_mesh.py --mesh 0.01.vtk -n 2 -o coarse_mesh

join_mesh.py --mesh mapped/mapped -o result.vtk -r recovery.json

vtk_calculator.py --mesh result.vtk -f x+y --data difference --indata "x + y" --diff
```
