### PR TITLE
Change outputs from ASCII to Binary

### DIFF
--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -265,13 +265,13 @@ def write_mesh(meshfile, filename, directory=None):
     extension = os.path.splitext(filename)[1]
     if (extension == ".vtk"):  # VTK Legacy format
         writer = vtk.vtkUnstructuredGridWriter()
+        writer.SetFileTypeToBinary()
     elif (extension == ".vtu"):  # VTK XML Unstructured Grid format
         writer = vtk.vtkXMLUnstructuredGridWriter()
     else:
         raise Exception("Unkown File extension: " + extension)
     writer.SetFileName(filename)
     writer.SetInputData(meshfile)
-    writer.SetFileTypeToBinary()
     writer.Write()
 
 

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -271,6 +271,7 @@ def write_mesh(meshfile, filename, directory=None):
         raise Exception("Unkown File extension: " + extension)
     writer.SetFileName(filename)
     writer.SetInputData(meshfile)
+    writer.SetFileTypeToBinary()
     writer.Write()
 
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -137,17 +137,17 @@ void readMainFile(Mesh &mesh, const std::string &filename, const std::string &da
   for (int i = 0; i < grid->GetNumberOfCells(); i++) {
     int cellType = grid->GetCell(i)->GetCellType();
 
-    //Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
+    // Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
     if (cellType == VTK_TRIANGLE) {
-      vtkCell *                cell = grid->GetCell(i);
+      vtkCell                 *cell = grid->GetCell(i);
       std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
       mesh.triangles.push_back(elem);
     } else if (cellType == VTK_LINE) {
-      vtkCell *                cell = grid->GetCell(i);
+      vtkCell                 *cell = grid->GetCell(i);
       std::array<Mesh::VID, 2> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1))};
       mesh.edges.push_back(elem);
     } else if (cellType == VTK_QUAD) {
-      vtkCell *                cell = grid->GetCell(i);
+      vtkCell                 *cell = grid->GetCell(i);
       std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
       mesh.quadrilaterals.push_back(elem);
     } else {
@@ -224,6 +224,7 @@ void MeshName::save(const Mesh &mesh, const std::string &dataname) const
         vtkSmartPointer<vtkUnstructuredGridWriter>::New();
     writer->SetInputData(grid);
     writer->SetFileName(filename().c_str());
+    writer->SetFileTypeToBinary();
     writer->Write();
   }
 }

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -378,13 +378,13 @@ def write_mesh(filename: str, points: List, data_index: List, cells=None, cell_t
     extension = os.path.splitext(filename)[1]
     if (extension == ".vtk"):  # VTK Legacy format
         writer = vtk.vtkUnstructuredGridWriter()
+        writer.SetFileTypeToBinary()
     elif (extension == ".vtu"):  # VTK XML Unstructured Grid format
         writer = vtk.vtkXMLUnstructuredGridWriter()
     else:
         raise Exception("Unkown File extension: " + extension)
     writer.SetFileName(filename)
     writer.SetInputData(vtkGrid)
-    writer.SetFileTypeToBinary()
     writer.Write()
     return
 

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -384,6 +384,7 @@ def write_mesh(filename: str, points: List, data_index: List, cells=None, cell_t
         raise Exception("Unkown File extension: " + extension)
     writer.SetFileName(filename)
     writer.SetInputData(vtkGrid)
+    writer.SetFileTypeToBinary()
     writer.Write()
     return
 
@@ -444,6 +445,7 @@ def vtu2vtk(inmesh, outmesh):
     writer = vtk.vtkUnstructuredGridWriter()
     writer.SetFileName(outmesh + ".vtk")
     writer.SetInputData(mesh)
+    writer.SetFileTypeToBinary()
     writer.Write()
     return
 

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -154,6 +154,7 @@ def main():
 
     if os.path.splitext(out_meshname)[1] == ".vtk":
         writer = vtk.vtkUnstructuredGridWriter()
+        writer.SetFileTypeToBinary()
     elif os.path.splitext(out_meshname)[1] == ".vtu":
         writer = vtk.vtkXMLUnstructuredGridWriter()
     else:
@@ -178,7 +179,6 @@ def main():
         out_meshname = os.path.join(directory, out_meshname)
 
     writer.SetFileName(out_meshname)
-    writer.SetFileTypeToBinary()
     writer.Write()
     logging.info("Written output to \"{}\".".format(out_meshname))
 

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -178,6 +178,7 @@ def main():
         out_meshname = os.path.join(directory, out_meshname)
 
     writer.SetFileName(out_meshname)
+    writer.SetFileTypeToBinary()
     writer.Write()
     logging.info("Written output to \"{}\".".format(out_meshname))
 


### PR DESCRIPTION
As discussed in https://github.com/precice/aste/issues/63 VTK ASCII  writer does not provide sufficient precision for `double` datatype in ASCII mode. This PR changes the output format of all ASTE tools to binary. 



