### PR TITLE
Add clang build and make CI fail on warnings

### DIFF
--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -11,7 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
+    env:
+      CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
     steps:
     - uses: actions/checkout@v2
     - name: install preCICE
@@ -22,21 +23,33 @@ jobs:
     - name: install VTK
       run: |
         sudo apt-get -y install libvtk7-dev
+    - name: prepare directories
+      run: |
+        mkdir build_gcc build_clang
     - name: build aste gcc
+      working-directory: build_gcc
+      env:
+        CC: gcc
+        CXX: g++
       run: | 
-        mkdir build_gcc && cd build_gcc && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wno-unused-parameter" .. && cmake --build .
+        cmake ..
+        cmake --build .
     - name: run test gcc
+      working-directory: build_gcc
       run: |
         ctest
     - name: install clang
       run: |
         sudo apt-get -y install clang
-    - name: switch directory
-      run: |
-        cd .. && mkdir build_clang && cd build_clang
     - name: build aste clang
+      working-directory: build_clang
+      env:
+        CC: clang
+        CXX: clang++
       run: |
-        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wno-unused-parameter" .. && cmake --build .
+        cmake ..
+        cmake --build .
     - name: run test clang
+      working-directory: build_clang
       run: |
         ctest

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get -y install libvtk7-dev
     - name: build aste gcc
       run: | 
-        mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" . && make all
+        mkdir build_gcc && cd build_gcc && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" .. && cmake --build .
     - name: run test gcc
       run: |
         ctest
@@ -36,7 +36,7 @@ jobs:
         cd .. && mkdir build_clang && cd build_clang
     - name: build aste clang
       run: |
-        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" . && make all
+        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" .. && cmake --build .
     - name: run test clang
       run: |
         ctest

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get -y install libvtk7-dev
     - name: build aste gcc
       run: | 
-        mkdir build_gcc && cd build_gcc && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" .. && cmake --build .
+        mkdir build_gcc && cd build_gcc && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wno-unused-parameter" .. && cmake --build .
     - name: run test gcc
       run: |
         ctest
@@ -36,7 +36,7 @@ jobs:
         cd .. && mkdir build_clang && cd build_clang
     - name: build aste clang
       run: |
-        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" .. && cmake --build .
+        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wno-unused-parameter" .. && cmake --build .
     - name: run test clang
       run: |
         ctest

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -22,9 +22,21 @@ jobs:
     - name: install VTK
       run: |
         sudo apt-get -y install libvtk7-dev
-    - name: build aste
+    - name: build aste gcc
       run: | 
-        cmake . && make all 
-    - name: run tests
+        mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" . && make all
+    - name: run test gcc
+      run: |
+        ctest
+    - name: install clang
+      run: |
+        sudo apt-get -y install clang
+    - name: switch directory
+      run: |
+        cd .. && mkdir build_clang && cd build_clang
+    - name: build aste clang
+      run: |
+        CC=clang CXX=clang++ cmake -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" . && make all
+    - name: run test clang
       run: |
         ctest


### PR DESCRIPTION
so that we have a better overview of warnings and different compiler behavior.
Debatable `-Wall -Wextra` (also considering precice). @fsimonis any opinion?