### PR TITLE
Change recovery file export name

### DIFF
--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -68,11 +68,11 @@ def read_meshes(prefix: str, partitions=None, recoveryPath=None):
         raise Exception("No partitions found")
 
     if os.path.exists(recoveryPath):
-        logging.info("No recovery data found. Meshes will be joined partition-wise")
-        return join_mesh_partitionwise(prefix, partitions)
-    else:
         logging.info("Recovery data found. Full recovery will be executed")
         return join_mesh_recovery(prefix, partitions, recoveryPath)
+    else:
+        logging.info("No recovery data found. Meshes will be joined partition-wise")
+        return join_mesh_partitionwise(prefix, partitions)
 
 
 def join_mesh_partitionwise(prefix: str, partitions: int):

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -22,6 +22,7 @@ import logging
 import os
 import json
 import vtk
+import os.path
 
 
 def parse_args():
@@ -47,8 +48,12 @@ def parse_args():
 def main():
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.logging))
+    if args.recovery:
+        recovery_file = args.recovery
+    else:
+        recovery_file = args.in_meshname + "recovery.json"
     out_meshname = args.out_meshname if args.out_meshname else args.in_meshname + "_joined.vtk"
-    joined_mesh = read_meshes(args.in_meshname, args.numparts, args.recovery)
+    joined_mesh = read_meshes(args.in_meshname, args.numparts, recovery_file)
     write_mesh(joined_mesh, out_meshname, args.directory)
 
 
@@ -62,7 +67,7 @@ def read_meshes(prefix: str, partitions=None, recoveryPath=None):
     if partitions == 0:
         raise Exception("No partitions found")
 
-    if recoveryPath is None:
+    if os.path.exists(recoveryPath):
         logging.info("No recovery data found. Meshes will be joined partition-wise")
         return join_mesh_partitionwise(prefix, partitions)
     else:

--- a/src/join_mesh.py
+++ b/src/join_mesh.py
@@ -51,7 +51,7 @@ def main():
     if args.recovery:
         recovery_file = args.recovery
     else:
-        recovery_file = args.in_meshname + "recovery.json"
+        recovery_file = args.in_meshname + "_recovery.json"
     out_meshname = args.out_meshname if args.out_meshname else args.in_meshname + "_joined.vtk"
     joined_mesh = read_meshes(args.in_meshname, args.numparts, recovery_file)
     write_mesh(joined_mesh, out_meshname, args.directory)

--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -409,14 +409,13 @@ def write_meshes(meshes, recoveryInfo, meshname: str, orig_mesh, directory=None)
     """
     Writes meshes to given directory.
     """
-
-    recoveryName = os.path.basename(os.path.normpath('recovery.json'))
     # Strip off the mesh-prefix for the directory creation
     mesh_prefix = os.path.basename(os.path.normpath(meshname))
+    recoveryName = os.path.basename(os.path.normpath(mesh_prefix+'_recovery.json'))
     if directory:
         # Get the absolute directory where we want to store the mesh
         directory = os.path.abspath(directory)
-        recoveryName = os.path.join(directory, 'recovery.json')
+        recoveryName = os.path.join(directory, mesh_prefix+'_recovery.json')
         os.makedirs(directory, exist_ok=True)
 
     for i in range(len(meshes)):


### PR DESCRIPTION
As mentioned in #79, having many mesh in one directory is an issue due to recovery file name 

This PR change the recovery filename from  `recovery.json` to `<mesh_prefix>_recovery.json` so that they can easily be identified.


Closes #79 