### PR TITLE
Fix mesh parsing for 2D meshes

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -218,7 +218,7 @@ void MeshName::save(const Mesh &mesh, const std::string &dataname) const
     grid->GetPointData()->SetVectors(data);
   } else {
     for (size_t i = 0; i < mesh.positions.size(); i++) {
-      data->InsertNextTuple(mesh.data[i]);
+      data->InsertNextTuple(&mesh.data[i]);
     }
     grid->GetPointData()->SetScalars(data);
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -76,10 +76,20 @@ void readMainFile(Mesh &mesh, const std::string &filename, const std::string &da
   // Get Points
   vtkPoints *Points    = grid->GetPoints();
   vtkIdType  NumPoints = grid->GetNumberOfPoints();
-  for (vtkIdType point = 0; point < NumPoints; point++) {
-    std::array<double, 3> vertexPosArr;
-    Points->GetPoint(point, vertexPosArr.data());
-    mesh.positions.push_back(vertexPosArr);
+  if (dim == 3) { // Parse all x,y,z
+    for (vtkIdType point = 0; point < NumPoints; point++) {
+      std::vector<double> vertexPosArr(3);
+      Points->GetPoint(point, vertexPosArr.data());
+      mesh.positions.push_back(vertexPosArr);
+    }
+  } else if (dim == 2) { // Parse only x,y
+    for (vtkIdType point = 0; point < NumPoints; point++) {
+      std::vector<double> vertexPosArr(3);
+      Points->GetPoint(point, vertexPosArr.data());
+      mesh.positions.push_back({vertexPosArr[0], vertexPosArr[1]});
+    }
+  } else {
+    throw std::runtime_error("Provided dimension (" + std::to_string(dim) + ") is not supported");
   }
   // Get Point Data
   vtkPointData *PD = grid->GetPointData();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -209,18 +209,18 @@ void MeshName::save(const Mesh &mesh, const std::string &dataname) const
       pointData.fill(0.0);
       for (size_t i = 0; i < mesh.positions.size(); i++) {
         for (int j = 0; j < numComp; j++) {
-          pointData.push_back(mesh.data[i * numComp + j]);
+          pointData[j] = mesh.data[i * numComp + j];
         }
         data->InsertNextTuple(pointData.data());
         pointData.fill(0.0);
       }
     }
-    grid->GetPointData()->SetVector(data);
+    grid->GetPointData()->SetVectors(data);
   } else {
     for (size_t i = 0; i < mesh.positions.size(); i++) {
       data->InsertNextTuple(mesh.data[i]);
     }
-    grid->GetPointData()->SetScalar(data);
+    grid->GetPointData()->SetScalars(data);
   }
 
   // Write file

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -76,7 +76,7 @@ namespace aste {
 
 } // namespace aste
 struct Mesh {
-  using Vertex   = std::array<double, 3>;
+  using Vertex   = std::vector<double>;
   using VID      = std::vector<Vertex>::size_type;
   using Edge     = std::array<VID, 2>;
   using Triangle = std::array<VID, 3>;

--- a/src/preciceMap.cpp
+++ b/src/preciceMap.cpp
@@ -64,11 +64,12 @@ std::vector<int> setupVertexIDs(precice::SolverInterface &interface,
                                 const aste::Mesh &mesh, int meshID)
 {
 #ifdef ASTE_SET_MESH_BLOCK
+  const auto          dim       = interface.getDimensions();
   const auto          nvertices = mesh.positions.size();
-  std::vector<double> posData(3 * nvertices);
+  std::vector<double> posData(dim * nvertices);
   for (unsigned long i = 0; i < nvertices; ++i) {
     const auto &pos = mesh.positions[i];
-    std::copy(pos.begin(), pos.end(), &posData[i * 3]);
+    std::copy(pos.begin(), pos.end(), &posData[i * dim]);
   }
 
   std::vector<int> vertexIDs(nvertices);


### PR DESCRIPTION
Problem:

ASTE was reading all the vertex locations (x,y,z) for both 3D and 2D meshes. This causes wrong and more vertices than actual ones

This PR fixes this problem for 2D cases, now ASTE only parses (x,y) components of vertex locations. 