### PR TITLE
95 empty partition on receiving participant leads to floating point exception

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -171,6 +171,8 @@ void MeshName::createDirectories() const
 
 void MeshName::save(const Mesh &mesh, const std::string &dataname) const
 {
+  if (mesh.positions.size() == 0)
+    return; // If mesh empty skip
   const int                            numComp = mesh.data.size() / mesh.positions.size();
   vtkSmartPointer<vtkDoubleArray>      data    = vtkDoubleArray::New();
   auto                                 ext     = fs::path(mesh.fname).extension();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -171,11 +171,12 @@ void MeshName::createDirectories() const
 
 void MeshName::save(const Mesh &mesh, const std::string &dataname) const
 {
-  if (mesh.positions.size() == 0)
-    return; // If mesh empty skip
-  const int                            numComp = mesh.data.size() / mesh.positions.size();
-  vtkSmartPointer<vtkDoubleArray>      data    = vtkDoubleArray::New();
-  auto                                 ext     = fs::path(mesh.fname).extension();
+  int numComp = 0;
+  if (mesh.positions.size() != 0) {
+    numComp = mesh.data.size() / mesh.positions.size();
+  }
+  vtkSmartPointer<vtkDoubleArray>      data = vtkDoubleArray::New();
+  auto                                 ext  = fs::path(mesh.fname).extension();
   vtkSmartPointer<vtkUnstructuredGrid> grid;
   if (ext == ".vtk") {
     vtkSmartPointer<vtkUnstructuredGridReader> reader = vtkSmartPointer<vtkUnstructuredGridReader>::New();


### PR DESCRIPTION

The number of components were calculated. by dividing data size to mesh points size which causes a floating-point exception (0/0 division in integers?) mentioned in issue #95.

This PR fixes this problem if the mesh is empty it sets the number of components to 0.

