### PR TITLE
Change file extensions for clang-format CI

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: '.'
-        exclude: ''
-        extensions: 'h,cc'
-        clangFormatVersion: 8
+        exclude: './src/json.hpp'
+        extensions: 'hpp,cpp,c,h'
+        clangFormatVersion: 12
         inplace: true
     - run: |
         git diff


### PR DESCRIPTION
Clang CI was only checking `*.cc` and `*.h` files which is weird since main repo mainly consist of `*.cpp` and `*.hpp` files.

This PR changes extensions to `*.c*` and `*.h*`  