### PR TITLE
Make sympy optional for VTK calculator

### DIFF
--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -301,7 +301,10 @@ class Calculator:
 
     @staticmethod
     def add_gradient(calc, vtk_dataset, inputfunc):
-        import sympy
+        try:
+            import sympy
+        except ImportError:
+            raise ImportError('For gradient calculations \"sympy\" is required please install \"sympy\" package.')
         logger = Calculator.get_logger()
         function_in_sympy = sympy.Matrix([sympy.parsing.parse_expr(Calculator.vtk_to_sympy(inputfunc))])
         variables = sympy.Matrix(sympy.symbols('x y z'))

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -304,7 +304,7 @@ class Calculator:
         try:
             import sympy
         except ImportError:
-            raise ImportError('For gradient calculations \"sympy\" is required please install \"sympy\" package.')
+            raise ImportError('For gradient calculations \"sympy\" is required please install the \"sympy\" package.')
         logger = Calculator.get_logger()
         function_in_sympy = sympy.Matrix([sympy.parsing.parse_expr(Calculator.vtk_to_sympy(inputfunc))])
         variables = sympy.Matrix(sympy.symbols('x y z'))

--- a/src/vtk_calculator.py
+++ b/src/vtk_calculator.py
@@ -5,7 +5,6 @@ import logging
 import os.path
 
 import numpy as np
-import sympy
 import vtk
 from vtk.util.numpy_support import numpy_to_vtk as n2v
 from vtk.util.numpy_support import vtk_to_numpy as v2n
@@ -302,6 +301,7 @@ class Calculator:
 
     @staticmethod
     def add_gradient(calc, vtk_dataset, inputfunc):
+        import sympy
         logger = Calculator.get_logger()
         function_in_sympy = sympy.Matrix([sympy.parsing.parse_expr(Calculator.vtk_to_sympy(inputfunc))])
         variables = sympy.Matrix(sympy.symbols('x y z'))


### PR DESCRIPTION
sympy is a relatively huge package and not required if a user doesn't need to work with gradient mapping. This PR makes sympy an optional dependency for `vtk_calculator.py`