### PR TITLE
Load and configure connectivity data only if required

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -84,7 +84,7 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool
       int cellType = grid->GetCell(i)->GetCellType();
 
       // Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
-      if (cellType == VTK_TRIANGLE) {
+      if (cellType == VTK_TRIANGLE && dim == 3) {
         vtkCell                 *cell = grid->GetCell(i);
         std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
         mesh.triangles.push_back(elem);
@@ -92,7 +92,7 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool
         vtkCell                 *cell = grid->GetCell(i);
         std::array<Mesh::VID, 2> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1))};
         mesh.edges.push_back(elem);
-      } else if (cellType == VTK_QUAD) {
+      } else if (cellType == VTK_QUAD && dim == 3) {
         vtkCell                 *cell = grid->GetCell(i);
         std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
         mesh.quadrilaterals.push_back(elem);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -84,18 +84,22 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool
       int cellType = grid->GetCell(i)->GetCellType();
 
       // Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
-      if (cellType == VTK_TRIANGLE && dim == 3) {
-        vtkCell                 *cell = grid->GetCell(i);
-        std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
-        mesh.triangles.push_back(elem);
+      if (cellType == VTK_TRIANGLE) {
+        if (dim == 3) {
+          vtkCell                 *cell = grid->GetCell(i);
+          std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
+          mesh.triangles.push_back(elem);
+        }
       } else if (cellType == VTK_LINE) {
         vtkCell                 *cell = grid->GetCell(i);
         std::array<Mesh::VID, 2> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1))};
         mesh.edges.push_back(elem);
-      } else if (cellType == VTK_QUAD && dim == 3) {
-        vtkCell                 *cell = grid->GetCell(i);
-        std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
-        mesh.quadrilaterals.push_back(elem);
+      } else if (cellType == VTK_QUAD) {
+        if (dim == 3) {
+          vtkCell                 *cell = grid->GetCell(i);
+          std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
+          mesh.quadrilaterals.push_back(elem);
+        }
       } else {
         std::cerr << "Invalid cell type in VTK file. Valid cell types are, VTK_LINE, VTK_TRIANGLE, and VTK_QUAD.";
         MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -105,6 +105,8 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool
         MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
       }
     }
+  } else {
+    std::cerr << "Connectivity information for " << mesh.fname << "skipped since connectivity is not required.";
   }
 };
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -42,7 +42,7 @@ Mesh::VID vtkToPos(vtkIdType id)
 }
 
 // Read vertices and mesh connectivity
-void readMesh(Mesh &mesh, const std::string &filename, const int dim)
+void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool requireConnectivy)
 {
   if (!fs::is_regular_file(filename)) {
     std::cerr << "The mesh file does not exist: " << filename;
@@ -79,25 +79,27 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim)
     mesh.positions.push_back(vertexLoc);
   }
 
-  for (int i = 0; i < grid->GetNumberOfCells(); i++) {
-    int cellType = grid->GetCell(i)->GetCellType();
+  if (requireConnectivy) {
+    for (int i = 0; i < grid->GetNumberOfCells(); i++) {
+      int cellType = grid->GetCell(i)->GetCellType();
 
-    // Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
-    if (cellType == VTK_TRIANGLE) {
-      vtkCell                 *cell = grid->GetCell(i);
-      std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
-      mesh.triangles.push_back(elem);
-    } else if (cellType == VTK_LINE) {
-      vtkCell                 *cell = grid->GetCell(i);
-      std::array<Mesh::VID, 2> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1))};
-      mesh.edges.push_back(elem);
-    } else if (cellType == VTK_QUAD) {
-      vtkCell                 *cell = grid->GetCell(i);
-      std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
-      mesh.quadrilaterals.push_back(elem);
-    } else {
-      std::cerr << "Invalid cell type in VTK file. Valid cell types are, VTK_LINE, VTK_TRIANGLE, and VTK_QUAD.";
-      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+      // Here we use static cast since VTK library returns a long long unsigned int however preCICE uses int for PointId's
+      if (cellType == VTK_TRIANGLE) {
+        vtkCell                 *cell = grid->GetCell(i);
+        std::array<Mesh::VID, 3> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2))};
+        mesh.triangles.push_back(elem);
+      } else if (cellType == VTK_LINE) {
+        vtkCell                 *cell = grid->GetCell(i);
+        std::array<Mesh::VID, 2> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1))};
+        mesh.edges.push_back(elem);
+      } else if (cellType == VTK_QUAD) {
+        vtkCell                 *cell = grid->GetCell(i);
+        std::array<Mesh::VID, 4> elem{vtkToPos(cell->GetPointId(0)), vtkToPos(cell->GetPointId(1)), vtkToPos(cell->GetPointId(2)), vtkToPos(cell->GetPointId(3))};
+        mesh.quadrilaterals.push_back(elem);
+      } else {
+        std::cerr << "Invalid cell type in VTK file. Valid cell types are, VTK_LINE, VTK_TRIANGLE, and VTK_QUAD.";
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+      }
     }
   }
 };
@@ -184,9 +186,9 @@ void readData(Mesh &mesh, const std::string &filename)
   }
 };
 
-void MeshName::loadMesh(Mesh &mesh, const int dim)
+void MeshName::loadMesh(Mesh &mesh, const int dim, const bool requireConnectivy)
 {
-  readMesh(mesh, filename(), dim);
+  readMesh(mesh, filename(), dim, requireConnectivy);
 }
 
 void MeshName::loadData(Mesh &mesh)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -42,7 +42,7 @@ Mesh::VID vtkToPos(vtkIdType id)
 }
 
 // Read vertices and mesh connectivity
-void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool requireConnectivy)
+void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool requireConnectivity)
 {
   if (!fs::is_regular_file(filename)) {
     std::cerr << "The mesh file does not exist: " << filename;
@@ -79,7 +79,7 @@ void readMesh(Mesh &mesh, const std::string &filename, const int dim, const bool
     mesh.positions.push_back(vertexLoc);
   }
 
-  if (requireConnectivy) {
+  if (requireConnectivity) {
     for (int i = 0; i < grid->GetNumberOfCells(); i++) {
       int cellType = grid->GetCell(i)->GetCellType();
 
@@ -190,9 +190,9 @@ void readData(Mesh &mesh, const std::string &filename)
   }
 };
 
-void MeshName::loadMesh(Mesh &mesh, const int dim, const bool requireConnectivy)
+void MeshName::loadMesh(Mesh &mesh, const int dim, const bool requireConnectivity)
 {
-  readMesh(mesh, filename(), dim, requireConnectivy);
+  readMesh(mesh, filename(), dim, requireConnectivity);
 }
 
 void MeshName::loadData(Mesh &mesh)

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -46,7 +46,7 @@ public:
 
   std::string filename() const;
 
-  void loadMesh(Mesh &mesh, const int dim, const bool requireConnectivy);
+  void loadMesh(Mesh &mesh, const int dim, const bool requireConnectivity);
   void loadData(Mesh &mesh);
   void resetData(Mesh &mesh);
   void save(const Mesh &mesh, const std::string &outputFilename) const;

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -41,13 +41,12 @@ struct ExecutionContext {
 
 class MeshName {
 public:
-
   MeshName(std::string meshname, std::string extension, const ExecutionContext &context)
       : _mname(std::move(meshname)), _ext(std::move(extension)), _context(context) {}
 
   std::string filename() const;
 
-  void loadMesh(Mesh &mesh, const int dim);
+  void loadMesh(Mesh &mesh, const int dim, const bool requireConnectivy);
   void loadData(Mesh &mesh);
   void resetData(Mesh &mesh);
   void save(const Mesh &mesh, const std::string &outputFilename) const;

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -45,8 +45,8 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     }
 
     VLOG(1) << "Loading mesh from " << asteInterface.meshes.front().filename();
-
-    asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim);
+    const bool requireConnectivy = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
+    asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivy);
 
     vertexIDs = setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);
     VLOG(1) << "Mesh setup completed on Rank " << context.rank;
@@ -207,8 +207,8 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
 
   auto asteInterface = asteConfiguration.asteInterfaces.front();
   VLOG(1) << "Loading mesh from " << asteInterface.meshes.front().filename();
-  ;
-  asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim);
+  const bool requireConnectivy = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
+  asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivy);
   asteInterface.meshes.front().loadData(asteInterface.mesh);
   VLOG(1) << "The mesh contains: " << asteInterface.mesh.summary();
   auto vertexIDs = aste::setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -47,7 +47,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     VLOG(1) << "Loading mesh from " << asteInterface.meshes.front().filename();
     const bool requireConnectivity = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
     asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivity);
-
+    VLOG(1) << "The loaded mesh " << asteInterface.meshes.front().filename() << " contains: " << asteInterface.mesh.summary();
     vertexIDs = setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);
     VLOG(1) << "Mesh setup completed on Rank " << context.rank;
     minMeshSize = std::max(minMeshSize, asteInterface.meshes.size());
@@ -210,7 +210,7 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
   const bool requireConnectivity = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
   asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivity);
   asteInterface.meshes.front().loadData(asteInterface.mesh);
-  VLOG(1) << "The mesh contains: " << asteInterface.mesh.summary();
+  VLOG(1) << "The loaded mesh " << asteInterface.meshes.front().filename() << " contains: " << asteInterface.mesh.summary();
   auto vertexIDs = aste::setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);
   VLOG(1) << "Mesh setup completed on Rank " << context.rank;
   double dt = preciceInterface.initialize();

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -45,8 +45,8 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     }
 
     VLOG(1) << "Loading mesh from " << asteInterface.meshes.front().filename();
-    const bool requireConnectivy = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
-    asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivy);
+    const bool requireConnectivity = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
+    asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivity);
 
     vertexIDs = setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);
     VLOG(1) << "Mesh setup completed on Rank " << context.rank;
@@ -207,8 +207,8 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
 
   auto asteInterface = asteConfiguration.asteInterfaces.front();
   VLOG(1) << "Loading mesh from " << asteInterface.meshes.front().filename();
-  const bool requireConnectivy = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
-  asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivy);
+  const bool requireConnectivity = preciceInterface.isMeshConnectivityRequired(asteInterface.meshID);
+  asteInterface.meshes.front().loadMesh(asteInterface.mesh, dim, requireConnectivity);
   asteInterface.meshes.front().loadData(asteInterface.mesh);
   VLOG(1) << "The mesh contains: " << asteInterface.mesh.summary();
   auto vertexIDs = aste::setupMesh(preciceInterface, asteInterface.mesh, asteInterface.meshID);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -88,7 +88,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
   if (interface.isMeshConnectivityRequired(meshID)) {
     VLOG(1) << "Mesh Setup: 2) Edges";
     const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
-    VLOG(1) << "Total " << edgeMap.size() << " edges are written";
+    VLOG(1) << "Total " << edgeMap.size() << " edges are configured";
     if (!mesh.triangles.empty()) {
       VLOG(1) << "Mesh Setup: 3) Triangles";
       for (auto const &triangle : mesh.triangles) {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -79,41 +79,51 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
 {
   auto tstart = std::chrono::steady_clock::now();
 
+  VLOG(1) << "Mesh Setup started for mesh: " << mesh.fname;
   VLOG(1) << "Mesh Setup: 1) Vertices";
   const auto vertexIDs = setupVertexIDs(interface, mesh, meshID);
 
   auto tconnectivity = std::chrono::steady_clock::now();
-  VLOG(1) << "Mesh Setup: 2) Edges";
-  const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
-  if (!mesh.triangles.empty()) {
-    VLOG(1) << "Mesh Setup: 3) Triangles";
-  }
-  for (auto const &triangle : mesh.triangles) {
-    const auto a = vertexIDs[triangle[0]];
-    const auto b = vertexIDs[triangle[1]];
-    const auto c = vertexIDs[triangle[2]];
 
-    interface.setMeshTriangle(meshID,
+  if (interface.isMeshConnectivityRequired(meshID)) {
+    VLOG(1) << "Mesh Setup: 2) Edges";
+    const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
+    VLOG(1) << "Total " << edgeMap.size() << " edges are written";
+    if (!mesh.triangles.empty()) {
+      VLOG(1) << "Mesh Setup: 3) Triangles";
+      for (auto const &triangle : mesh.triangles) {
+        const auto a = vertexIDs[triangle[0]];
+        const auto b = vertexIDs[triangle[1]];
+        const auto c = vertexIDs[triangle[2]];
+
+        interface.setMeshTriangle(meshID,
+                                  edgeMap.at(Edge{a, b}),
+                                  edgeMap.at(Edge{b, c}),
+                                  edgeMap.at(Edge{c, a}));
+      }
+    } else {
+      VLOG(1) << "Mesh Setup: 3) No Triangles are found/required. Skipped";
+    }
+    if (!mesh.quadrilaterals.empty()) {
+      VLOG(1) << "Mesh Setup: 4) Quadrilaterals";
+      for (auto const &quadrilateral : mesh.quadrilaterals) {
+        const auto a = vertexIDs[quadrilateral[0]];
+        const auto b = vertexIDs[quadrilateral[1]];
+        const auto c = vertexIDs[quadrilateral[2]];
+        const auto d = vertexIDs[quadrilateral[3]];
+
+        interface.setMeshQuad(meshID,
                               edgeMap.at(Edge{a, b}),
                               edgeMap.at(Edge{b, c}),
-                              edgeMap.at(Edge{c, a}));
+                              edgeMap.at(Edge{c, d}),
+                              edgeMap.at(Edge{d, a}));
+      }
+    } else {
+      VLOG(1) << "Mesh Setup: 4) No Quadrilaterals are found/required. Skipped";
+    }
+  } else {
+    VLOG(1) << "Mesh Setup: 2) Connectivity information on mesh " << mesh.fname << " not required skipped.";
   }
-  if (!mesh.quadrilaterals.empty()) {
-    VLOG(1) << "Mesh Setup: 4) Quadrilaterals";
-  }
-  for (auto const &quadrilateral : mesh.quadrilaterals) {
-    const auto a = vertexIDs[quadrilateral[0]];
-    const auto b = vertexIDs[quadrilateral[1]];
-    const auto c = vertexIDs[quadrilateral[2]];
-    const auto d = vertexIDs[quadrilateral[3]];
-
-    interface.setMeshQuad(meshID,
-                          edgeMap.at(Edge{a, b}),
-                          edgeMap.at(Edge{b, c}),
-                          edgeMap.at(Edge{c, d}),
-                          edgeMap.at(Edge{d, a}));
-  }
-
   auto tend = std::chrono::steady_clock::now();
 
   VLOG(1)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -122,7 +122,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
       VLOG(1) << "Mesh Setup: 4) No Quadrilaterals are found/required. Skipped";
     }
   } else {
-    VLOG(1) << "Mesh Setup: 2) Connectivity information on mesh " << mesh.fname << " not required skipped.";
+    VLOG(1) << "Mesh Setup: 2) Skipped connectivity information on mesh " << mesh.fname << " as it is not  required.";
   }
   auto tend = std::chrono::steady_clock::now();
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -85,8 +85,9 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
   auto tconnectivity = std::chrono::steady_clock::now();
   VLOG(1) << "Mesh Setup: 2) Edges";
   const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
-
-  VLOG(1) << "Mesh Setup: 3) Triangles";
+  if (!mesh.triangles.empty()) {
+    VLOG(1) << "Mesh Setup: 3) Triangles";
+  }
   for (auto const &triangle : mesh.triangles) {
     const auto a = vertexIDs[triangle[0]];
     const auto b = vertexIDs[triangle[1]];
@@ -97,8 +98,9 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
                               edgeMap.at(Edge{b, c}),
                               edgeMap.at(Edge{c, a}));
   }
-
-  VLOG(1) << "Mesh Setup: 4) Quadrilaterals";
+  if (!mesh.quadrilaterals.empty()) {
+    VLOG(1) << "Mesh Setup: 4) Quadrilaterals";
+  }
   for (auto const &quadrilateral : mesh.quadrilaterals) {
     const auto a = vertexIDs[quadrilateral[0]];
     const auto b = vertexIDs[quadrilateral[1]];

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -122,7 +122,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
       VLOG(1) << "Mesh Setup: 4) No Quadrilaterals are found/required. Skipped";
     }
   } else {
-    VLOG(1) << "Mesh Setup: 2) Skipped connectivity information on mesh " << mesh.fname << " as it is not  required.";
+    VLOG(1) << "Mesh Setup: 2) Skipped connectivity information on mesh \"" << mesh.fname << "\" as it is not required.";
   }
   auto tend = std::chrono::steady_clock::now();
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -90,7 +90,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
     const auto edgeMap = setupEdgeIDs(interface, mesh, meshID, vertexIDs);
     VLOG(1) << "Total " << edgeMap.size() << " edges are configured";
     if (!mesh.triangles.empty()) {
-      VLOG(1) << "Mesh Setup: 3) Triangles";
+      VLOG(1) << "Mesh Setup: 3) " << mesh.triangles.size() << " Triangles";
       for (auto const &triangle : mesh.triangles) {
         const auto a = vertexIDs[triangle[0]];
         const auto b = vertexIDs[triangle[1]];
@@ -105,7 +105,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
       VLOG(1) << "Mesh Setup: 3) No Triangles are found/required. Skipped";
     }
     if (!mesh.quadrilaterals.empty()) {
-      VLOG(1) << "Mesh Setup: 4) Quadrilaterals";
+      VLOG(1) << "Mesh Setup: 4) " << mesh.quadrilaterals.size() << " Quadrilaterals";
       for (auto const &quadrilateral : mesh.quadrilaterals) {
         const auto a = vertexIDs[quadrilateral[0]];
         const auto b = vertexIDs[quadrilateral[1]];

--- a/tests/read_test.cpp
+++ b/tests/read_test.cpp
@@ -9,22 +9,26 @@ void readtest(const ReadCase &current_case)
 
   BOOST_TEST(mesh.positions.size() == 12);
   BOOST_TEST(mesh.edges.size() == 2);
-  BOOST_TEST(mesh.quadrilaterals.size() == 2);
-  BOOST_TEST(mesh.triangles.size() == 4);
-  //std::cout << "Number of mesh elements are correctly loaded\n";
+  if (current_case.dim == 3) {
+    BOOST_TEST(mesh.quadrilaterals.size() == 2);
+    BOOST_TEST(mesh.triangles.size() == 4);
+  }
+  // std::cout << "Number of mesh elements are correctly loaded\n";
 
   BOOST_TEST(mesh.edges[1][0] == 10);
   BOOST_TEST(mesh.edges[1][1] == 11);
-  //std::cout << "Edges loaded correctly\n";
-  BOOST_TEST(mesh.triangles[0][0] == 0);
-  BOOST_TEST(mesh.triangles[0][1] == 1);
-  BOOST_TEST(mesh.triangles[0][2] == 3);
-  //std::cout << "Triangles loaded correctly\n";
-  BOOST_TEST(mesh.quadrilaterals[1][0] == 4);
-  BOOST_TEST(mesh.quadrilaterals[1][1] == 5);
-  BOOST_TEST(mesh.quadrilaterals[1][2] == 8);
-  BOOST_TEST(mesh.quadrilaterals[1][3] == 7);
-  //std::cout << "Quads loaded correctly\n";
+  // std::cout << "Edges loaded correctly\n";
+  if (current_case.dim == 3) {
+    BOOST_TEST(mesh.triangles[0][0] == 0);
+    BOOST_TEST(mesh.triangles[0][1] == 1);
+    BOOST_TEST(mesh.triangles[0][2] == 3);
+    // std::cout << "Triangles loaded correctly\n";
+    BOOST_TEST(mesh.quadrilaterals[1][0] == 4);
+    BOOST_TEST(mesh.quadrilaterals[1][1] == 5);
+    BOOST_TEST(mesh.quadrilaterals[1][2] == 8);
+    BOOST_TEST(mesh.quadrilaterals[1][3] == 7);
+  }
+  // std::cout << "Quads loaded correctly\n";
   aste::MeshData caseData(aste::datatype::WRITE, current_case.dim, current_case.dataname, 1);
   mesh.meshdata.push_back(caseData);
   read_test.loadData(mesh);

--- a/tests/read_test.cpp
+++ b/tests/read_test.cpp
@@ -5,20 +5,23 @@ void readtest(const ReadCase &current_case)
 
   auto       read_test = aste::BaseName{current_case.fname}.with(aste::ExecutionContext());
   aste::Mesh mesh;
-  read_test.loadMesh(mesh, current_case.dim, true);
+  read_test.loadMesh(mesh, current_case.dim, current_case.connectivity);
 
   BOOST_TEST(mesh.positions.size() == 12);
-  BOOST_TEST(mesh.edges.size() == 2);
-  if (current_case.dim == 3) {
+  if (current_case.connectivity) {
+    BOOST_TEST(mesh.edges.size() == 2);
+  }
+  if (current_case.dim == 3 && current_case.connectivity) {
     BOOST_TEST(mesh.quadrilaterals.size() == 2);
     BOOST_TEST(mesh.triangles.size() == 4);
   }
   // std::cout << "Number of mesh elements are correctly loaded\n";
-
-  BOOST_TEST(mesh.edges[1][0] == 10);
-  BOOST_TEST(mesh.edges[1][1] == 11);
+  if (current_case.connectivity) {
+    BOOST_TEST(mesh.edges[1][0] == 10);
+    BOOST_TEST(mesh.edges[1][1] == 11);
+  }
   // std::cout << "Edges loaded correctly\n";
-  if (current_case.dim == 3) {
+  if (current_case.dim == 3 && current_case.connectivity) {
     BOOST_TEST(mesh.triangles[0][0] == 0);
     BOOST_TEST(mesh.triangles[0][1] == 1);
     BOOST_TEST(mesh.triangles[0][2] == 3);

--- a/tests/read_test.cpp
+++ b/tests/read_test.cpp
@@ -5,7 +5,7 @@ void readtest(const ReadCase &current_case)
 
   auto       read_test = aste::BaseName{current_case.fname}.with(aste::ExecutionContext());
   aste::Mesh mesh;
-  read_test.loadMesh(mesh, current_case.dim);
+  read_test.loadMesh(mesh, current_case.dim, true);
 
   BOOST_TEST(mesh.positions.size() == 12);
   BOOST_TEST(mesh.edges.size() == 2);

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -4,34 +4,64 @@
 
 BOOST_AUTO_TEST_SUITE(read_write_tests)
 
-BOOST_AUTO_TEST_CASE(read_test_scalar)
+BOOST_AUTO_TEST_CASE(read_test_scalar_w_connectivity)
 {
-  readtest(ReadCase{"./reference_scalars", "Scalars", 1});
+  readtest(ReadCase{"./reference_scalars", "Scalars", 1, true});
 }
 
-BOOST_AUTO_TEST_CASE(read_test_2dvector)
+BOOST_AUTO_TEST_CASE(read_test_scalar_wo_connectivity)
 {
-  readtest(ReadCase{"./reference_vector2d", "Vector2D", 2});
+  readtest(ReadCase{"./reference_scalars", "Scalars", 1, false});
 }
 
-BOOST_AUTO_TEST_CASE(read_test_3dvector)
+BOOST_AUTO_TEST_CASE(read_test_2dvector_w_connectivity)
 {
-  readtest(ReadCase{"./reference_vector3d", "Vector3D", 3});
+  readtest(ReadCase{"./reference_vector2d", "Vector2D", 2, true});
 }
 
-BOOST_AUTO_TEST_CASE(write_test_scalar)
+BOOST_AUTO_TEST_CASE(read_test_2dvector_wo_connectivity)
 {
-  writetest(WriteCase{"./reference_scalars", "./scalar_write", "Scalars", 1});
+  readtest(ReadCase{"./reference_vector2d", "Vector2D", 2, false});
 }
 
-BOOST_AUTO_TEST_CASE(write_test_2dvector)
+BOOST_AUTO_TEST_CASE(read_test_3dvector_w_connectivity)
 {
-  writetest(WriteCase{"./reference_vector2d", "./vector2d_write", "Vector2D", 2});
+  readtest(ReadCase{"./reference_vector3d", "Vector3D", 3, true});
 }
 
-BOOST_AUTO_TEST_CASE(write_test_3dvector)
+BOOST_AUTO_TEST_CASE(read_test_3dvector_wo_connectivity)
 {
-  writetest(WriteCase{"./reference_vector3d", "./vector3d_write", "Vector3D", 3});
+  readtest(ReadCase{"./reference_vector3d", "Vector3D", 3, false});
 }
 
-BOOST_AUTO_TEST_SUITE_END() //read_write_tests
+BOOST_AUTO_TEST_CASE(write_test_scalar_w_connectivity)
+{
+  writetest(WriteCase{"./reference_scalars", "./scalar_write", "Scalars", 1, true});
+}
+
+BOOST_AUTO_TEST_CASE(write_test_scalar_wo_connectivity)
+{
+  writetest(WriteCase{"./reference_scalars", "./scalar_write", "Scalars", 1, false});
+}
+
+BOOST_AUTO_TEST_CASE(write_test_2dvector_w_connectivity)
+{
+  writetest(WriteCase{"./reference_vector2d", "./vector2d_write", "Vector2D", 2, true});
+}
+
+BOOST_AUTO_TEST_CASE(write_test_2dvector_wo_connectivity)
+{
+  writetest(WriteCase{"./reference_vector2d", "./vector2d_write", "Vector2D", 2, false});
+}
+
+BOOST_AUTO_TEST_CASE(write_test_3dvector_w_connectivity)
+{
+  writetest(WriteCase{"./reference_vector3d", "./vector3d_write", "Vector3D", 3, true});
+}
+
+BOOST_AUTO_TEST_CASE(write_test_3dvector_wo_connectivity)
+{
+  writetest(WriteCase{"./reference_vector3d", "./vector3d_write", "Vector3D", 3, false});
+}
+
+BOOST_AUTO_TEST_SUITE_END() // read_write_tests

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -7,6 +7,7 @@ struct ReadCase {
   std::string fname{};
   std::string dataname{};
   int         dim{};
+  bool        connectivity;
 };
 
 struct WriteCase {
@@ -14,6 +15,7 @@ struct WriteCase {
   std::string fname{};
   std::string dataname{};
   int         dim{};
+  bool        connectivity;
 };
 
 void writetest(const WriteCase &current_case);

--- a/tests/write_test.cpp
+++ b/tests/write_test.cpp
@@ -11,7 +11,7 @@ void writetest(const WriteCase &current_case)
 
   auto       write_test = aste::BaseName{current_case.basename}.with(aste::ExecutionContext());
   aste::Mesh testMesh;
-  write_test.loadMesh(testMesh, current_case.dim);
+  write_test.loadMesh(testMesh, current_case.dim, true);
   aste::MeshData caseData(aste::datatype::WRITE, current_case.dim, current_case.dataname, 1);
   testMesh.meshdata.push_back(caseData);
   write_test.loadData(testMesh);
@@ -27,7 +27,7 @@ void writetest(const WriteCase &current_case)
   // Read written data and compare with created data
   auto       read = aste::BaseName{"write_test"}.with(aste::ExecutionContext());
   aste::Mesh testMeshRead;
-  read.loadMesh(testMeshRead, current_case.dim);
+  read.loadMesh(testMeshRead, current_case.dim, true);
   testMeshRead.meshdata.push_back(caseData);
   read.loadData(testMeshRead);
 

--- a/tests/write_test.cpp
+++ b/tests/write_test.cpp
@@ -11,7 +11,7 @@ void writetest(const WriteCase &current_case)
 
   auto       write_test = aste::BaseName{current_case.basename}.with(aste::ExecutionContext());
   aste::Mesh testMesh;
-  write_test.loadMesh(testMesh, current_case.dim, true);
+  write_test.loadMesh(testMesh, current_case.dim, current_case.connectivity);
   aste::MeshData caseData(aste::datatype::WRITE, current_case.dim, current_case.dataname, 1);
   testMesh.meshdata.push_back(caseData);
   write_test.loadData(testMesh);
@@ -27,21 +27,25 @@ void writetest(const WriteCase &current_case)
   // Read written data and compare with created data
   auto       read = aste::BaseName{"write_test"}.with(aste::ExecutionContext());
   aste::Mesh testMeshRead;
-  read.loadMesh(testMeshRead, current_case.dim, true);
+  read.loadMesh(testMeshRead, current_case.dim, current_case.connectivity);
   testMeshRead.meshdata.push_back(caseData);
   read.loadData(testMeshRead);
 
   // Check Elements are correctly written
   BOOST_TEST(testMeshRead.positions.size() == testMesh.positions.size());
-  BOOST_TEST(testMeshRead.edges.size() == testMesh.edges.size());
-  if (current_case.dim == 3) {
+  if (current_case.connectivity) {
+    BOOST_TEST(testMeshRead.edges.size() == testMesh.edges.size());
+  }
+  if (current_case.dim == 3 && current_case.connectivity) {
     BOOST_TEST(testMeshRead.quadrilaterals.size() == testMesh.quadrilaterals.size());
     BOOST_TEST(testMeshRead.triangles.size() == testMesh.triangles.size());
   }
   // Check Edges
-  BOOST_TEST(testMeshRead.edges[1][0] == testMesh.edges[1][0]);
-  BOOST_TEST(testMeshRead.edges[1][1] == testMesh.edges[1][1]);
-  if (current_case.dim == 3) {
+  if (current_case.connectivity) {
+    BOOST_TEST(testMeshRead.edges[1][0] == testMesh.edges[1][0]);
+    BOOST_TEST(testMeshRead.edges[1][1] == testMesh.edges[1][1]);
+  }
+  if (current_case.dim == 3 && current_case.connectivity) {
     // Check Triangles
     BOOST_TEST(testMeshRead.triangles[0][0] == testMesh.triangles[0][0]);
     BOOST_TEST(testMeshRead.triangles[0][1] == testMesh.triangles[0][1]);

--- a/tests/write_test.cpp
+++ b/tests/write_test.cpp
@@ -34,20 +34,24 @@ void writetest(const WriteCase &current_case)
   // Check Elements are correctly written
   BOOST_TEST(testMeshRead.positions.size() == testMesh.positions.size());
   BOOST_TEST(testMeshRead.edges.size() == testMesh.edges.size());
-  BOOST_TEST(testMeshRead.quadrilaterals.size() == testMesh.quadrilaterals.size());
-  BOOST_TEST(testMeshRead.triangles.size() == testMesh.triangles.size());
+  if (current_case.dim == 3) {
+    BOOST_TEST(testMeshRead.quadrilaterals.size() == testMesh.quadrilaterals.size());
+    BOOST_TEST(testMeshRead.triangles.size() == testMesh.triangles.size());
+  }
   // Check Edges
   BOOST_TEST(testMeshRead.edges[1][0] == testMesh.edges[1][0]);
   BOOST_TEST(testMeshRead.edges[1][1] == testMesh.edges[1][1]);
-  // Check Triangles
-  BOOST_TEST(testMeshRead.triangles[0][0] == testMesh.triangles[0][0]);
-  BOOST_TEST(testMeshRead.triangles[0][1] == testMesh.triangles[0][1]);
-  BOOST_TEST(testMeshRead.triangles[0][2] == testMesh.triangles[0][2]);
-  // Check Quads
-  BOOST_TEST(testMeshRead.quadrilaterals[1][0] == testMesh.quadrilaterals[1][0]);
-  BOOST_TEST(testMeshRead.quadrilaterals[1][1] == testMesh.quadrilaterals[1][1]);
-  BOOST_TEST(testMeshRead.quadrilaterals[1][2] == testMesh.quadrilaterals[1][2]);
-  BOOST_TEST(testMeshRead.quadrilaterals[1][3] == testMesh.quadrilaterals[1][3]);
+  if (current_case.dim == 3) {
+    // Check Triangles
+    BOOST_TEST(testMeshRead.triangles[0][0] == testMesh.triangles[0][0]);
+    BOOST_TEST(testMeshRead.triangles[0][1] == testMesh.triangles[0][1]);
+    BOOST_TEST(testMeshRead.triangles[0][2] == testMesh.triangles[0][2]);
+    // Check Quads
+    BOOST_TEST(testMeshRead.quadrilaterals[1][0] == testMesh.quadrilaterals[1][0]);
+    BOOST_TEST(testMeshRead.quadrilaterals[1][1] == testMesh.quadrilaterals[1][1]);
+    BOOST_TEST(testMeshRead.quadrilaterals[1][2] == testMesh.quadrilaterals[1][2]);
+    BOOST_TEST(testMeshRead.quadrilaterals[1][3] == testMesh.quadrilaterals[1][3]);
+  }
   // Check Datasize
   BOOST_TEST(testMeshRead.meshdata.front().dataVector.size() == testMesh.meshdata.front().dataVector.size());
   // Check Data Values


### PR DESCRIPTION
ASTE was configuring mesh connectivity even if it is not required at all. Now it would only load it when it is required.

Also provides tri and quads only in 3D cases not in 2D cases.
