### PR TITLE
partition_mesh.py does not find libmetisAPI.so under lib64

### DIFF
--- a/src/partition_mesh.py
+++ b/src/partition_mesh.py
@@ -231,6 +231,7 @@ class MeshPartitioner:
             cellPtr.append(cellPtr[-1] + len(cell))
         binpath = os.path.dirname(__file__)
         libpath = os.path.normpath(os.path.join(binpath, "../lib"))
+        lib64path = os.path.normpath(os.path.join(binpath, "../lib64"))
         os_type = platform.system()
         if os_type == "Linux":
             ext = ".so"
@@ -242,6 +243,8 @@ class MeshPartitioner:
             libmetispath = os.path.join(binpath, "libmetisAPI" + ext)
         elif os.path.isfile(os.path.join(libpath, "libmetisAPI" + ext)):
             libmetispath = os.path.join(libpath, "libmetisAPI" + ext)
+        elif os.path.isfile(os.path.join(lib64path, "libmetisAPI" + ext)):
+            libmetispath = os.path.join(lib64path, "libmetisAPI" + ext)
         else:
             raise Exception("libmetisAPI" + ext + " cannot found!")
         libmetis = cdll.LoadLibrary(libmetispath)


### PR DESCRIPTION
see issue #123 

On centOS 7 (red hat based distribution) the directory containing libraries on 64 system are called lib64. But partition_mesh.py only looks into "../lib". I modified the script partition_mesh.py to look into and lib and lib64.

Works on CentOS 7.9.
Regards