### PR TITLE
Fixed column name

### DIFF
--- a/tools/mapping-tester/plotstats.py
+++ b/tools/mapping-tester/plotstats.py
@@ -29,7 +29,7 @@ def main(argv):
         grouped.get_group(key).plot(
             ax=ax,
             x="count",
-            y=["relative-l2", "median"],
+            y=["relative-l2", "median(abs)"],
             loglog=True,
             title=str(key)
         )


### PR DESCRIPTION
The script looks for a column name "median" but the actual name when the mapping-tester is used is "median(abs)"