### PR TITLE
Fixed missing units in plotconv.py

### DIFF
--- a/tools/mapping-tester/plotconv.py
+++ b/tools/mapping-tester/plotconv.py
@@ -121,7 +121,7 @@ def plotMemory(df, prefix):
             color=color
         )
     ax.set_xlabel("edge length(h) of mesh A")
-    ax.set_ylabel("peak memory of participant B")
+    ax.set_ylabel("peak memory of participant B [bytes]")
 
     #plotConv(ax, df, yname)
 


### PR DESCRIPTION
When plotting memory consumption with the mapping tester, units weren't shown.