### PR TITLE
Handle ASTE and preCICE logging

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,10 +91,11 @@ The following subsections explain each part of ASTE more in detail. All ASTE mod
 | Flag          | Explanation                                                   |
 | ------------- | ------------------------------------------------------------- |
 | --aste-config | ASTE configuration file (only used for replay mode)           |
-| -v            | Enables verbose logging output from preCICE                   |
+| -v            | Enables verbose logging output                                |
+| -a            | Enables logging from secondary ranks                          |
 | -c            | To specify preCICE config file (default="precice-config.xml") |
 | -p            | Participant name, which can take the arguments `A` or `B`     |
-| --vector      | A bool switch to specify vector data (default=`False`)       |
+| --vector      | A bool switch to specify vector data (default=`False`)        |
 
 {% important %}
 The `--mesh` option here can be different from the mesh defined in the configuration file. ASTE expects here the filename (prefix) of the mesh file (VTK or VTU), which is different from meshes defined in the simulation setup.

--- a/examples/lci_2d/precice-config.xml
+++ b/examples/lci_2d/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="2">
     <data:scalar name="Data" />

--- a/examples/lci_3d/precice-config.xml
+++ b/examples/lci_3d/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="3">
     <data:scalar name="Data" />

--- a/examples/nn/precice-config.xml
+++ b/examples/nn/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="3">
     <data:scalar name="Data" />

--- a/examples/nng_scalar/precice-config.xml
+++ b/examples/nng_scalar/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="false" />
 
   <solver-interface dimensions="3" experimental="true">
     <data:scalar name="Data" />

--- a/examples/nng_vector/precice-config.xml
+++ b/examples/nng_vector/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="3" experimental="true">
     <data:vector name="Data" />

--- a/examples/replay_mode/precice-config.xml
+++ b/examples/replay_mode/precice-config.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log>
-    <sink
-      filter="%Severity% > debug and %Rank% = 0"
-      format="---[precice] %ColorizedSeverity% %Message%"
-      enabled="true" />
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="2">
     <data:vector name="Force" />

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -22,10 +22,7 @@ OptionMap getOptions(int argc, char *argv[])
       "precice-aste-run will look for timeseries as well as distributed meshes (e.g. from preCICE exports) "
       "automatically and load them if required.")(
       "output", po::value<std::string>(),
-      "Output file name.")
-      ("vector", po::bool_switch(), "Distinguish between vector valued data and scalar data")
-      ("verbose,v", po::bool_switch(), "Enable verbose output")
-      ("all,a", po::bool_switch(), "Enable output from secondary ranks");
+      "Output file name.")("vector", po::bool_switch(), "Distinguish between vector valued data and scalar data")("verbose,v", po::bool_switch(), "Enable verbose output")("all,a", po::bool_switch(), "Enable output from secondary ranks");
 
   po::variables_map vm;
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -22,9 +22,10 @@ OptionMap getOptions(int argc, char *argv[])
       "precice-aste-run will look for timeseries as well as distributed meshes (e.g. from preCICE exports) "
       "automatically and load them if required.")(
       "output", po::value<std::string>(),
-      "Output file name.")(
-      "vector", po::bool_switch(),
-      "Distinguish between vector valued data and scalar data")("verbose,v", po::bool_switch(), "Enable verbose output"); // not explicitly used, handled by easylogging
+      "Output file name.")
+      ("vector", po::bool_switch(), "Distinguish between vector valued data and scalar data")
+      ("verbose,v", po::bool_switch(), "Enable verbose output")
+      ("all,a", po::bool_switch(), "Enable output from secondary ranks");
 
   po::variables_map vm;
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,18 +1,36 @@
 #include "logger.hpp"
+#include <boost/log/attributes/constant.hpp>
 
 namespace attrs   = boost::log::attributes;
 namespace expr    = boost::log::expressions;
 namespace logging = boost::log;
 
 // Defines a global logger initialization routine
-BOOST_LOG_GLOBAL_LOGGER_INIT(my_logger, src::severity_logger_mt<boost::log::trivial::severity_level>)
+BOOST_LOG_GLOBAL_LOGGER_INIT(my_logger, src::severity_logger_mt<logging::trivial::severity_level>)
 {
-  src::severity_logger_mt<boost::log::trivial::severity_level> lg;
+  src::severity_logger_mt<logging::trivial::severity_level> lg;
+  lg.add_attribute("ASTE", attrs::constant<bool>(true));
   logging::add_common_attributes();
-  auto format = expr::stream << "---[ASTE] " << expr::message;
-  logging::add_console_log(std::clog, keywords::format = format);
-  logging::core::get()->set_filter(
-      logging::trivial::severity >= logging::trivial::info);
-
   return lg;
+}
+
+void addLogIdentity(const std::string &participant, int rank)
+{
+  my_logger::get().add_attribute("Participant", attrs::constant<std::string>(participant));
+  my_logger::get().add_attribute("Rank", attrs::constant<int>(rank));
+}
+
+void addLogSink(bool verbose)
+{
+  std::string filter = "( %Severity% >= ";
+  filter.append(verbose ? "debug" : "info");
+  filter.append(" ) and %ASTE%");
+  std::cerr << filter;
+
+  std::string formatter = "---[ASTE:%Participant%:%Rank%] %Message%";;
+
+  logging::add_console_log(
+      std::clog,
+      keywords::format = logging::parse_formatter(formatter),
+      keywords::filter = logging::parse_filter(filter));
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -27,7 +27,8 @@ void addLogSink(bool verbose)
   filter.append(" ) and %ASTE%");
   std::cerr << filter;
 
-  std::string formatter = "---[ASTE:%Participant%:%Rank%] %Message%";;
+  std::string formatter = "---[ASTE:%Participant%:%Rank%] %Message%";
+  ;
 
   logging::add_console_log(
       std::clog,

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -9,7 +9,7 @@ namespace expr    = boost::log::expressions;
 namespace logging = boost::log;
 
 // Defines a global logger initialization routine
-BOOST_LOG_GLOBAL_LOGGER_INIT(my_logger, src::severity_logger_mt<logging::trivial::severity_level>)
+BOOST_LOG_GLOBAL_LOGGER_INIT(my_logger, logger_t)
 {
   src::severity_logger_mt<logging::trivial::severity_level> lg;
   lg.add_attribute("ASTE", attrs::constant<bool>(true));
@@ -30,8 +30,8 @@ void addLogSink(bool verbose)
   // Either "ASTE" or "preCICE"
   auto origin = expr::if_(expr::has_attr<bool>("ASTE"))[expr::stream << "ASTE"].else_[expr::stream << "preCICE"];
 
-  // For preCICE logs "(Module in Function)"
-  auto location = expr::if_(!expr::has_attr<bool>("ASTE"))
+  // For preCICE logs "(Module in Function)" if verbose
+  auto location = expr::if_(verbose && !expr::has_attr<bool>("ASTE"))
       [expr::stream << "(" << expr::attr<std::string>("Module") << " in " << expr::attr<std::string>("Function") << ") "];
 
   auto formatter = expr::stream

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -47,21 +47,16 @@ void addLogSink(LogLevel ll, LogRankFilter lrf)
       [expr::stream << "(" << expr::attr<std::string>("Module") << " in " << expr::attr<std::string>("Function") << ") "];
 
   // Format the severity
-  auto blankSeverity = 
-    expr::if_(logging::trivial::error == logging::trivial::severity)
-    [ expr::stream << "ERROR" ]
-    .else_[
-     expr::stream << expr::if_(logging::trivial::warning == logging::trivial::severity)
-      [ expr::stream << "WARNING" ]
-      .else_[
-     expr::stream << expr::if_(logging::trivial::info == logging::trivial::severity)
-      [ expr::stream << "INFO" ]
-      .else_[
-     expr::stream << expr::if_(logging::trivial::debug == logging::trivial::severity)
-        [ expr::stream << "DEBUG" ]
-      .else_[
-        expr::stream << logging::trivial::severity
-    ]]]];
+  auto blankSeverity =
+      expr::if_(logging::trivial::error == logging::trivial::severity)
+          [expr::stream << "ERROR"]
+              .else_[expr::stream << expr::if_(logging::trivial::warning == logging::trivial::severity)
+                                         [expr::stream << "WARNING"]
+                                             .else_[expr::stream << expr::if_(logging::trivial::info == logging::trivial::severity)
+                                                                        [expr::stream << "INFO"]
+                                                                            .else_[expr::stream << expr::if_(logging::trivial::debug == logging::trivial::severity)
+                                                                                                       [expr::stream << "DEBUG"]
+                                                                                                           .else_[expr::stream << logging::trivial::severity]]]];
 
   auto formatter = expr::stream
                    << "---["

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -34,7 +34,7 @@ typedef boost::log::sources::severity_logger_mt<boost::log::trivial::severity_le
 // declares a global logger with a custom initialization
 BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t);
 
-void addLogIdentity(const std::string& participant, int rank);
+void addLogIdentity(const std::string &participant, int rank);
 void addLogSink(bool verbose);
 
 #define ASTE_DEBUG BOOST_LOG_SEV(my_logger::get(), boost::log::trivial::severity_level::debug)

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -35,7 +35,11 @@ typedef boost::log::sources::severity_logger_mt<boost::log::trivial::severity_le
 BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t);
 
 void addLogIdentity(const std::string &participant, int rank);
-void addLogSink(bool verbose);
+
+enum struct LogLevel : bool { Quiet, Verbose };
+enum struct LogRankFilter : bool { All, OnlyPrimary };
+
+void addLogSink(LogLevel ll, LogRankFilter lrf);
 
 #define ASTE_DEBUG BOOST_LOG_SEV(my_logger::get(), boost::log::trivial::severity_level::debug)
 #define ASTE_INFO BOOST_LOG_SEV(my_logger::get(), boost::log::trivial::severity_level::info)

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -36,8 +36,10 @@ BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t);
 
 void addLogIdentity(const std::string &participant, int rank);
 
-enum struct LogLevel : bool { Quiet, Verbose };
-enum struct LogRankFilter : bool { All, OnlyPrimary };
+enum struct LogLevel : bool { Quiet,
+                              Verbose };
+enum struct LogRankFilter : bool { All,
+                                   OnlyPrimary };
 
 void addLogSink(LogLevel ll, LogRankFilter lrf);
 

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -32,7 +32,10 @@ using boost::shared_ptr;
 typedef boost::log::sources::severity_logger_mt<boost::log::trivial::severity_level> logger_t;
 
 // declares a global logger with a custom initialization
-BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t)
+BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t);
+
+void addLogIdentity(const std::string& participant, int rank);
+void addLogSink(bool verbose);
 
 #define ASTE_DEBUG BOOST_LOG_SEV(my_logger::get(), boost::log::trivial::severity_level::debug)
 #define ASTE_INFO BOOST_LOG_SEV(my_logger::get(), boost::log::trivial::severity_level::info)

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -8,6 +8,8 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
   aste::asteConfig asteConfiguration;
   asteConfiguration.load(asteConfigName);
   const std::string participantName = asteConfiguration.participantName;
+  addLogIdentity(participantName, context.rank);
+  ASTE_INFO << "ASTE Running in replay mode";
 
   precice::SolverInterface preciceInterface(participantName, asteConfiguration.preciceConfigFilename, context.rank, context.size);
   const int                dim = preciceInterface.getDimensions();
@@ -189,6 +191,9 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
   const std::string dataname        = options["data"].as<std::string>();
   const bool        isVector        = options["vector"].as<bool>();
   const std::string preciceConfig   = options["precice-config"].as<std::string>();
+
+  addLogIdentity(participantName, context.rank);
+  ASTE_INFO << "ASTE Running in mapping test mode";
 
   aste::asteConfig asteConfiguration;
 

--- a/src/precice-aste-run.cpp
+++ b/src/precice-aste-run.cpp
@@ -9,7 +9,10 @@ int main(int argc, char *argv[])
 {
   auto context = aste::initializeMPI(argc, argv);
   auto options = getOptions(argc, argv);
-  addLogSink(options["verbose"].as<bool>());
+
+  addLogSink(
+      options["verbose"].as<bool>() ? LogLevel::Verbose : LogLevel::Quiet,
+      options["all"].as<bool>() ? LogRankFilter::All : LogRankFilter::OnlyPrimary);
 
   if (options.count("aste-config")) {
     aste::runReplayMode(context, options["aste-config"].as<std::string>());

--- a/src/precice-aste-run.cpp
+++ b/src/precice-aste-run.cpp
@@ -1,3 +1,4 @@
+#include <boost/log/attributes/constant.hpp>
 #include <mpi.h>
 #include <string>
 #include "logger.hpp"
@@ -8,16 +9,11 @@ int main(int argc, char *argv[])
 {
   auto context = aste::initializeMPI(argc, argv);
   auto options = getOptions(argc, argv);
-
-  if (options["verbose"].as<bool>()) {
-    boost::log::core::get()->set_filter(logging::trivial::severity >= logging::trivial::debug);
-  }
+  addLogSink(options["verbose"].as<bool>());
 
   if (options.count("aste-config")) {
-    ASTE_INFO << "ASTE Running on re-play mode";
     aste::runReplayMode(context, options["aste-config"].as<std::string>());
   } else {
-    ASTE_INFO << "ASTE Running on mapping test mode";
     aste::runMapperMode(context, options);
   }
   ASTE_INFO << "Finalizing ASTE";

--- a/tools/mapping-tester/config-template.xml
+++ b/tools/mapping-tester/config-template.xml
@@ -2,9 +2,8 @@
 
 <precice-configuration {% if syncmode %} sync-mode="1" {% endif %} >
 
-  <log enabled="true">
-    <sink type="stream" output="stdout" filter="%Severity% > debug" format='%TimeStamp(format="%H:%M:%S.%f")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|%Severity%%Message%' enabled="true" />
-    <sink type="file" output="debug.log" filter="" format='%TimeStamp(format="%H:%M:%S.%f")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|%Severity%%Message%' enabled="true"/>
+  <log>
+    <sink type="file" output="debug.log" filter="" format='%TimeStamp(format="%H:%M:%S.%f")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|%Severity%%Message%' />
   </log>
 
   <solver-interface dimensions="3">

--- a/tools/mapping-tester/generate.py
+++ b/tools/mapping-tester/generate.py
@@ -144,7 +144,7 @@ def createRunScript(outdir, path, case):
     )
 
     # Generate runner script
-    acmd = '/usr/bin/time -f %M -a -o memory-A.log precice-aste-run -v -p A --data "{}" --mesh {} || kill 0 &'.format(
+    acmd = '/usr/bin/time -f %M -a -o memory-A.log precice-aste-run -v -a -p A --data "{}" --mesh {} || kill 0 &'.format(
         case["function"], ameshLocation
     )
     if aranks > 1:
@@ -156,7 +156,7 @@ def createRunScript(outdir, path, case):
         os.path.join(outdir, "meshes", bmesh, str(branks), bmesh), path
     )
     mapped_data_name = case["function"] + "(mapped)"
-    bcmd = '/usr/bin/time -f %M -a -o memory-B.log precice-aste-run -v -p B --data "{}" --mesh {} --output mapped || kill 0 &'.format(
+    bcmd = '/usr/bin/time -f %M -a -o memory-B.log precice-aste-run -v -a -p B --data "{}" --mesh {} --output mapped || kill 0 &'.format(
         mapped_data_name, bmeshLocation
     )
     if branks > 1:

--- a/tools/split-mesh-error/elasticTube/precice-config.xml
+++ b/tools/split-mesh-error/elasticTube/precice-config.xml
@@ -2,9 +2,7 @@
 
 <precice-configuration>
 
-  <log enabled="1">
-    <sink filter="%Severity% > debug" output="stdout" type="stream" enabled="1"/>
-  </log>
+  <log enabled="0" />
 
   <solver-interface dimensions="3">
 


### PR DESCRIPTION
This PR changes the ASTE logger to:
* Tags log entries from `ASTE` using the constant boolean attribute `ASTE`.
* ~~Output only ASTE log entries by filtering `... and %ASTE%` in the sink.~~
* Adds additional attributes for `Participant` and `Rank`. This allows to distinguish log entries when running ASTE in parallel.

~~After this, preCICE will still output ASTE logs by default. A similar change will soon be merged in preCICE itself.
Until then, we can configure a log filter in preCICE `... and not %ASTE%` to remove ASTE log entries from the preCICE log.~~

_edit:_ ASTE will now handle logs from both preCICE and ASTE.

preCICE configs should disable all sinks by defining `<log enabled="false"></log>`


Related to #73