### PR TITLE
Move version detection for NNG and Tetra Support to code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,19 +22,6 @@ find_package (Threads REQUIRED)
 
 find_package(precice REQUIRED CONFIG)
 
-
-# 2.4.0 has a bug so it requires something greater than 2.4.0 for NN
-# Also, tetrahedra appeared after 2.4.0
-IF(${precice_VERSION} VERSION_GREATER "2.4.0")
-  SET(SUPPORT_NN_GRADIENT_MAPPING_AND_TETRA ON)
-ELSE()
-  SET(SUPPORT_NN_GRADIENT_MAPPING_AND_TETRA OFF)
-ENDIF()
-
-option(ASTE_NN_GRADIENT_MAPPING_AND_TETRA "Support nearest neighbour gradient mapping." ${SUPPORT_NN_GRADIENT_MAPPING_AND_TETRA})
-
-MESSAGE(STATUS "Support for nearest-neighbor-gradient mapping and tetrahedra: ${ASTE_NN_GRADIENT_MAPPING_AND_TETRA}")
-
 find_package(Boost 1.65.1 REQUIRED COMPONENTS log log_setup system program_options filesystem unit_test_framework)
 
 find_package(VTK REQUIRED)
@@ -62,10 +49,6 @@ target_link_libraries(precice-aste-run
 
 if(ASTE_SET_MESH_BLOCK)
   target_compile_definitions(precice-aste-run PRIVATE ASTE_SET_MESH_BLOCK)
-endif()
-
-if(ASTE_NN_GRADIENT_MAPPING_AND_TETRA)
-  target_compile_definitions(precice-aste-run PRIVATE ASTE_NN_GRADIENT_MAPPING_AND_TETRA)
 endif()
 
 if(METIS_FOUND)

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -3,10 +3,9 @@
 #include "logger.hpp"
 #include "utilities.hpp"
 
-#ifdef PRECICE_VERSION
-#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
-#define ASTE_NN_GRADIENT_MAPPING_AND_TETRA
-#endif
+#ifndef PRECICE_VERSION_GREATER_EQUAL
+// compatibility with older versions
+#define PRECICE_VERSION_GREATER_EQUAL(x, y, z) FALSE
 #endif
 
 void aste::runReplayMode(const aste::ExecutionContext &context, const std::string &asteConfigName)
@@ -35,7 +34,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     for (const auto dataname : asteInterface.writeVectorNames) {
       const int dataID = preciceInterface.getDataID(dataname, asteInterface.meshID);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, dim, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, dim, dataname, dataID, dim));
@@ -51,7 +50,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     for (const auto dataname : asteInterface.writeScalarNames) {
       const int dataID = preciceInterface.getDataID(dataname, asteInterface.meshID);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, 1, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, 1, dataname, dataID, dim));
@@ -142,7 +141,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
             break;
           }
         }
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
         else if (meshdata.type == aste::datatype::GRADIENT) {
           switch (meshdata.numcomp) {
           case 1:
@@ -214,7 +213,7 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
     if (isVector) {
       asteInterface.writeVectorNames.push_back(dataname);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, dim, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, dim, dataname, dataID, dim));
@@ -223,7 +222,7 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
     } else {
       asteInterface.writeScalarNames.push_back(dataname);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, 1, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, 1, dataname, dataID, dim));
@@ -277,7 +276,7 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
             break;
           }
         }
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
         else if (meshdata.type == aste::datatype::GRADIENT) {
           switch (meshdata.numcomp) {
           case 1:
@@ -329,7 +328,7 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
           }
           ASTE_DEBUG << "Data written: " << asteInterface.mesh.previewData(meshdata);
         }
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
         else if (meshdata.type == aste::datatype::GRADIENT) {
           switch (meshdata.numcomp) {
           case 1:

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -3,6 +3,12 @@
 #include "logger.hpp"
 #include "utilities.hpp"
 
+#ifdef PRECICE_VERSION
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
+#define ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#endif
+#endif
+
 void aste::runReplayMode(const aste::ExecutionContext &context, const std::string &asteConfigName)
 {
   aste::asteConfig asteConfiguration;
@@ -29,7 +35,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     for (const auto dataname : asteInterface.writeVectorNames) {
       const int dataID = preciceInterface.getDataID(dataname, asteInterface.meshID);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, dim, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING
+#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, dim, dataname, dataID, dim));
@@ -45,7 +51,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
     for (const auto dataname : asteInterface.writeScalarNames) {
       const int dataID = preciceInterface.getDataID(dataname, asteInterface.meshID);
       asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::WRITE, 1, dataname, dataID));
-#ifdef ASTE_NN_GRADIENT_MAPPING
+#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
       if (preciceInterface.isGradientDataRequired(dataID)) {
         asteInterface.writeVectorNames.push_back(dataname + "_gradient");
         asteInterface.mesh.meshdata.push_back(aste::MeshData(aste::datatype::GRADIENT, 1, dataname, dataID, dim));
@@ -136,7 +142,7 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
             break;
           }
         }
-#ifdef ASTE_NN_GRADIENT_MAPPING
+#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
         else if (meshdata.type == aste::datatype::GRADIENT) {
           switch (meshdata.numcomp) {
           case 1:

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -3,11 +3,6 @@
 #include "logger.hpp"
 #include "utilities.hpp"
 
-#ifndef PRECICE_VERSION_GREATER_EQUAL
-// compatibility with older versions
-#define PRECICE_VERSION_GREATER_EQUAL(x, y, z) FALSE
-#endif
-
 void aste::runReplayMode(const aste::ExecutionContext &context, const std::string &asteConfigName)
 {
   aste::asteConfig asteConfiguration;

--- a/src/modes.hpp
+++ b/src/modes.hpp
@@ -12,6 +12,11 @@
 
 #include "precice/SolverInterface.hpp"
 
+#ifndef PRECICE_VERSION_GREATER_EQUAL
+// compatibility with older versions
+#define PRECICE_VERSION_GREATER_EQUAL(x, y, z) FALSE
+#endif
+
 namespace aste {
 /**
  * @brief The function runs ASTE in replay mode where aste simulates a participant in preCICE

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,9 +1,8 @@
 #include "utilities.hpp"
 
-#ifdef PRECICE_VERSION
-#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
-#define ASTE_NN_GRADIENT_MAPPING_AND_TETRA
-#endif
+#ifndef PRECICE_VERSION_GREATER_EQUAL
+// compatibility with older versions
+#define PRECICE_VERSION_GREATER_EQUAL(x, y, z) FALSE
 #endif
 
 bool operator==(const Edge &lhs, const Edge &rhs)
@@ -128,7 +127,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
       ASTE_DEBUG << "Mesh Setup: 4) No Quadrilaterals are found/required. Skipped";
     }
 
-#ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
     if (!mesh.tetrahedra.empty()) {
       ASTE_DEBUG << "Mesh Setup: 5) " << mesh.tetrahedra.size() << " Tetrahedra";
       for (auto const &tetra : mesh.tetrahedra) {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,10 +1,5 @@
 #include "utilities.hpp"
 
-#ifndef PRECICE_VERSION_GREATER_EQUAL
-// compatibility with older versions
-#define PRECICE_VERSION_GREATER_EQUAL(x, y, z) FALSE
-#endif
-
 bool operator==(const Edge &lhs, const Edge &rhs)
 {
   return (lhs.vA == rhs.vA) && (lhs.vB == rhs.vB);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,5 +1,11 @@
 #include "utilities.hpp"
 
+#ifdef PRECICE_VERSION
+#if PRECICE_VERSION_GREATER_EQUAL(2, 5, 0)
+#define ASTE_NN_GRADIENT_MAPPING_AND_TETRA
+#endif
+#endif
+
 bool operator==(const Edge &lhs, const Edge &rhs)
 {
   return (lhs.vA == rhs.vA) && (lhs.vB == rhs.vB);
@@ -121,6 +127,7 @@ std::vector<int> aste::setupMesh(precice::SolverInterface &interface, const aste
     } else {
       ASTE_DEBUG << "Mesh Setup: 4) No Quadrilaterals are found/required. Skipped";
     }
+
 #ifdef ASTE_NN_GRADIENT_MAPPING_AND_TETRA
     if (!mesh.tetrahedra.empty()) {
       ASTE_DEBUG << "Mesh Setup: 5) " << mesh.tetrahedra.size() << " Tetrahedra";


### PR DESCRIPTION
For Nearest Neighbour Gradient and Tetra support, the requirement for preCICE was at least 2.5.0, and checks have been done using CMake. As preCICE offers, new versioning macros use them to detect the preCICE version instead of the usage of CMake.