### PR TITLE
Add examples to CTest

### DIFF
--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -23,6 +23,10 @@ jobs:
       - name: install VTK
         run: |
           sudo apt-get -y install libvtk7-dev
+      - name: install example dependencies
+        working-directory: tests/example
+        run: |
+          python3 -m pip install sympy scipy jinja2
       - name: prepare directories
         run: |
           mkdir build_gcc build_clang
@@ -54,19 +58,3 @@ jobs:
         working-directory: build_clang
         run: |
           ctest
-      - name: install example dependencies
-        working-directory: tests/example
-        run: |
-          python3 -m pip install sympy
-      - name: run example
-        working-directory: tests/example
-        run: |
-          ./run-all.sh
-      - name: install mapping-tester dependencies
-        working-directory: tests/
-        run: |
-          python3 -m pip install scipy jinja2
-      - name: test mapping-tester
-        working-directory: tests/mapping-tester-example
-        run: |
-          ./run.sh

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 30
     env:
       CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
+      CTEST_OUTPUT_ON_FAILURE: "Yes"
     steps:
       - uses: actions/checkout@v2
       - name: install preCICE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,10 +135,15 @@ foreach(example IN LISTS _examples)
     RUN_SERIAL ON)
 endforeach()
 
-add_test(NAME aste.example.mapping-tester
-  COMMAND run.sh)
+add_test(NAME aste.example.mapping-tester.setup
+  COMMAND clean.sh
+  FIXTURE_SETUP mapping-tester)
 
-set_tests_properties(aste.example.mapping-tester
+add_test(NAME aste.example.mapping-tester
+  COMMAND run.sh
+  FIXTURE_REQUIRES mapping-tester)
+
+set_tests_properties(aste.example.mapping-tester aste.example.mapping-tester.setup
   PROPERTIES
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/mapping-tester-example"
   ENVIRONMENT "PATH=$ENV{PATH}:${CMAKE_BINARY_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,3 +134,13 @@ foreach(example IN LISTS _examples)
     LABELS example
     RUN_SERIAL ON)
 endforeach()
+
+add_test(NAME aste.example.mapping-tester
+  COMMAND run.sh)
+
+set_tests_properties(aste.example.mapping-tester
+  PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/mapping-tester-example"
+  ENVIRONMENT "PATH=$ENV{PATH}:${CMAKE_BINARY_DIR}"
+  LABELS example
+  RUN_SERIAL ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,3 +113,24 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-partition ${CMAKE_
 enable_testing()
 
 add_test(NAME read_write_test  COMMAND testing WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
+
+# Detect and register examples as tests
+
+set(_examples lci_2d lci_3d nn nng_scalar nng_vector)
+
+foreach(example IN LISTS _examples)
+  add_test(NAME aste.example.${example}.setup
+    COMMAND clean.sh
+    FIXTURE_SETUP ${example})
+
+  add_test(NAME aste.example.${example}
+    COMMAND run.sh
+    FIXTURE_REQUIRES ${example})
+
+  set_tests_properties(aste.example.${example} aste.example.${example}.setup
+    PROPERTIES
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/example/${example}"
+    ENVIRONMENT "PATH=$ENV{PATH}:${CMAKE_BINARY_DIR}"
+    LABELS example
+    RUN_SERIAL ON)
+endforeach()

--- a/tests/example/lci_2d/clean.sh
+++ b/tests/example/lci_2d/clean.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -e -x
 
-rm -r precice-run &
-rm precice-*-events*.json &
-rm *.log &
-rm map*.vtk &
-rm fine_mesh_*.vtk &
+rm -f -r precice-run
+rm -f precice-*-events*.json
+rm -f *.log
+rm -f map*.vtk
+rm -f fine_mesh_*.vtk
+rm -f precice-*.json

--- a/tests/example/lci_3d/clean.sh
+++ b/tests/example/lci_3d/clean.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
-rm -r precice-run &
-rm precice-*-events*.json &
-rm *.log &
-rm map*.vtk &
-rm fine_mesh_*.vtk &
+rm -f -r precice-run
+rm -f precice-*-events*.json
+rm -f *.log
+rm -f map*.vtk
+rm -f fine_mesh_*.vtk

--- a/tests/example/nn/clean.sh
+++ b/tests/example/nn/clean.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
-rm -r precice-run &
-rm precice-*-events*.json &
-rm *.log &
-rm map*.vtk &
-rm fine_mesh_*.vtk &
+rm -f -r precice-run
+rm -f precice-*-events*.json
+rm -f *.log
+rm -f map*.vtk
+rm -f fine_mesh_*.vtk

--- a/tests/example/nng_scalar/clean.sh
+++ b/tests/example/nng_scalar/clean.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
-rm -r precice-run &
-rm precice-*-events*.json &
-rm *.log &
-rm map*.vtk &
-rm fine_mesh_*.vtk &
+rm -f -r precice-run
+rm -f precice-*-events*.json
+rm -f *.log
+rm -f map*.vtk
+rm -f fine_mesh_*.vtk

--- a/tests/example/nng_vector/clean.sh
+++ b/tests/example/nng_vector/clean.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
-rm -r precice-run &
-rm precice-*-events*.json &
-rm *.log &
-rm map*.vtk &
-rm fine_mesh_*.vtk &
+rm -f -r precice-run
+rm -f precice-*-events*.json
+rm -f *.log
+rm -f map*.vtk
+rm -f fine_mesh_*.vtk

--- a/tests/mapping-tester-example/clean.sh
+++ b/tests/mapping-tester-example/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -f test-statistics.csv
+rm -fr ./case/


### PR DESCRIPTION
This PR adds the provided examples to ctest.
Example tests are labelled `example`, so they can be skipped using `ctest -LE example`.

Each test consists of a test and a setup fixture which runs the `clean.sh` script of the test. This allows to check the output of a test.
New examples need to be added to the `_examples` list in the `CMakeLists.txt`.
