### PR TITLE
Fix gradient calculations

### DIFF
--- a/src/precice-aste-evaluate
+++ b/src/precice-aste-evaluate
@@ -427,11 +427,17 @@ class Calculator:
             ]
             gradient_name_list = [dataname + "_gradient"]
             gradient_function = [
-                str(gradients[0])
+                "("
+                + str(gradients[0])
+                + ")"
                 + "*iHat+"
+                + "("
                 + str(gradients[1])
+                + ")"
                 + "*jHat+"
+                + "("
                 + str(gradients[2])
+                + ")"
                 + "*kHat"
             ]
         # Add gradient function to vtk_dataset


### PR DESCRIPTION
## Main changes of this PR

In the gradient calculation, parenthesis was missing which led to a wrong calculation.

eg.

`(y-x)^2` should have a gradient `(2*x-2y)*iHat+(-2*x+2y)*jHat+0*kHat`  but get a gradient `2*x - 2*y*iHat+-2*x + 2*y*jHat+0*kHat` as a function which is not a vector equivalent to `-2*y*iHat+2*y*jHat+0*kHat + (2*x-2*x)` which is not a vector.


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
