### PR TITLE
Change boost::filesystem to std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package (Threads REQUIRED)
 
 find_package(precice REQUIRED CONFIG)
 
-find_package(Boost 1.71.0 REQUIRED COMPONENTS log log_setup system program_options filesystem unit_test_framework)
+find_package(Boost 1.71.0 REQUIRED COMPONENTS log log_setup system program_options unit_test_framework)
 
 option(ASTE_USE_VTK_COMPONENTS "Find VTK with components" OFF)
 if(ASTE_USE_VTK_COMPONENTS)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <limits>

--- a/src/mesh.hpp
+++ b/src/mesh.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 
 #include <mpi.h>
 
@@ -39,7 +38,7 @@
 
 namespace aste {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 class BaseName;
 struct Mesh;
 class MeshName;

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -2,7 +2,7 @@
 
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <algorithm>
 #include <cassert>
@@ -22,7 +22,7 @@
 
 #include "precice/SolverInterface.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 using VertexID = int;
 using EdgeID   = int;

--- a/tests/write_test.cpp
+++ b/tests/write_test.cpp
@@ -1,10 +1,9 @@
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <cstdlib>
+#include <filesystem>
 
 #include "testing.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 void writetest(const WriteCase &current_case)
 {


### PR DESCRIPTION
## Main changes of this PR

As a result of bumping to C++17, there is no need to boost::filesystem,  instead, STL implementation can be used. 

This PR changes filesystem libraries to STL implementation.



## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
