### PR TITLE
Change test name from test to precice-aste-test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ if(METIS_FOUND)
 endif()
 
 
-add_executable(test-aste tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
-target_include_directories(test-aste PRIVATE src thirdparty)
-target_link_libraries(test-aste
+add_executable(test-precice-aste tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
+target_include_directories(test-precice-aste PRIVATE src thirdparty)
+target_link_libraries(test-precice-aste
   ${Boost_LIBRARIES}
   MPI::MPI_CXX
   ${VTK_LIBRARIES}
@@ -78,7 +78,7 @@ if (VTK_VERSION VERSION_LESS "8.90.0")
 else ()
   # vtk_module_autoinit is needed
   vtk_module_autoinit(
-    TARGETS precice-aste-run test-aste
+    TARGETS precice-aste-run test-precice-aste
     MODULES ${VTK_LIBRARIES}
     )
 endif()
@@ -96,7 +96,7 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-partition ${CMAKE_
 
 enable_testing()
 
-add_test(NAME read_write_test  COMMAND test-aste WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
+add_test(NAME read_write_test  COMMAND test-precice-aste WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 
 # Detect and register examples as tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ if(METIS_FOUND)
 endif()
 
 
-add_executable(precice-aste-test tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
-target_include_directories(precice-aste-test PRIVATE src thirdparty)
-target_link_libraries(precice-aste-test
+add_executable(test-aste tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
+target_include_directories(test-aste PRIVATE src thirdparty)
+target_link_libraries(test-aste
   ${Boost_LIBRARIES}
   MPI::MPI_CXX
   ${VTK_LIBRARIES}
@@ -78,7 +78,7 @@ if (VTK_VERSION VERSION_LESS "8.90.0")
 else ()
   # vtk_module_autoinit is needed
   vtk_module_autoinit(
-    TARGETS precice-aste-run precice-aste-test
+    TARGETS precice-aste-run test-aste
     MODULES ${VTK_LIBRARIES}
     )
 endif()
@@ -96,7 +96,7 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-partition ${CMAKE_
 
 enable_testing()
 
-add_test(NAME read_write_test  COMMAND precice-aste-test WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
+add_test(NAME read_write_test  COMMAND test-aste WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 
 # Detect and register examples as tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-partition ${CMAKE_
 
 enable_testing()
 
-add_test(NAME read_write_test  COMMAND testing WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
+add_test(NAME read_write_test  COMMAND precice-aste-test WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 
 # Detect and register examples as tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED YES)
 set (CMAKE_CXX_EXTENSIONS NO)
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
@@ -63,9 +64,9 @@ if(METIS_FOUND)
 endif()
 
 
-add_executable(testing tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
-target_include_directories(testing PRIVATE src thirdparty)
-target_link_libraries(testing
+add_executable(precice-aste-test tests/testing.cpp tests/read_test.cpp tests/write_test.cpp src/mesh.cpp src/logger.cpp)
+target_include_directories(precice-aste-test PRIVATE src thirdparty)
+target_link_libraries(precice-aste-test
   ${Boost_LIBRARIES}
   MPI::MPI_CXX
   ${VTK_LIBRARIES}
@@ -77,7 +78,7 @@ if (VTK_VERSION VERSION_LESS "8.90.0")
 else ()
   # vtk_module_autoinit is needed
   vtk_module_autoinit(
-    TARGETS precice-aste-run testing
+    TARGETS precice-aste-run precice-aste-test
     MODULES ${VTK_LIBRARIES}
     )
 endif()


### PR DESCRIPTION
## Main changes of this PR

The test executable is called `testing` is clashes with Cmake testing directory.  `test` is located for Cmake itself. This PR changes the test executable to `precice-aste-test`

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
