### PR TITLE
Use env time to bypass built-in time instead of /usr/bin

### DIFF
--- a/tools/mapping-tester/generate.py
+++ b/tools/mapping-tester/generate.py
@@ -152,7 +152,7 @@ def createRunScript(outdir, path, case):
     )
 
     # Generate runner script
-    acmd = '/usr/bin/time -f %M -a -o memory-A.log precice-aste-run -v -a -p A --data "{}" --mesh {} || kill 0 &'.format(
+    acmd = 'env time -f %M -a -o memory-A.log precice-aste-run -v -a -p A --data "{}" --mesh {} || kill 0 &'.format(
         case["function"], ameshLocation
     )
     if aranks > 1:
@@ -164,7 +164,7 @@ def createRunScript(outdir, path, case):
         os.path.join(outdir, "meshes", bmesh, str(branks), bmesh), path
     )
     mapped_data_name = case["function"] + "(mapped)"
-    bcmd = '/usr/bin/time -f %M -a -o memory-B.log precice-aste-run -v -a -p B --data "{}" --mesh {} --output mapped || kill 0 &'.format(
+    bcmd = 'env time -f %M -a -o memory-B.log precice-aste-run -v -a -p B --data "{}" --mesh {} --output mapped || kill 0 &'.format(
         mapped_data_name, bmeshLocation
     )
     if branks > 1:


### PR DESCRIPTION
## Main changes of this PR

which is more robust if time is not installed (disk-less mode on some HPC systems) and time is not installed in /usr

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
