### PR TITLE
Fix vertex resolution in partitioner and joiner

### DIFF
--- a/src/precice-aste-join
+++ b/src/precice-aste-join
@@ -232,6 +232,7 @@ class MeshJoiner:
         # Initialize Joined Mesh
         joined_mesh = vtk.vtkUnstructuredGrid()
         joined_points = vtk.vtkPoints()
+        joined_points.SetDataTypeToDouble()
         joined_points.SetNumberOfPoints(size)
         joined_data_arrays = None
         joined_cells = vtk.vtkCellArray()

--- a/src/precice-aste-join
+++ b/src/precice-aste-join
@@ -144,6 +144,7 @@ class MeshJoiner:
         logger.info("Starting partition-wise mesh merge")
         joined_mesh = vtk.vtkUnstructuredGrid()
         joined_points = vtk.vtkPoints()
+        joined_points.SetDataTypeToDouble()
         joined_data_arrays = None
         joined_cells = vtk.vtkCellArray()
         joined_cell_types = []

--- a/src/precice-aste-partition
+++ b/src/precice-aste-partition
@@ -496,6 +496,7 @@ class MeshPartitioner:
 
         vtk_grid = vtk.vtkUnstructuredGrid()
         vtkpoints = vtk.vtkPoints()
+        vtkpoints.SetDataTypeToDouble()
         vtkpoints.SetNumberOfPoints(len(points))
         for id, point in enumerate(points):
             vtkpoints.SetPoint(id, point)


### PR DESCRIPTION
## Main changes of this PR

Given the accuracy of our mapping methods, we need double precision to evaluate the accuracy well enough and exceed (in my experiment) the threshold of 1e-8.

