### PR TITLE
Fix SEGFAULT on missing mesh

### DIFF
--- a/changelog-entries/196.md
+++ b/changelog-entries/196.md
@@ -1,0 +1,1 @@
+- Fixed SEGFAULT in `precice-aste-run` if no mesh is found for the given name.

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -200,6 +200,11 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
   }
 
   auto asteInterface = asteConfiguration.asteInterfaces.front();
+  if (asteInterface.meshes.empty()) {
+    ASTE_ERROR << "ERROR: Could not find meshes for name: " << meshname;
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
   ASTE_INFO << "Loading mesh from " << asteInterface.meshes.front().filename();
   const bool requireConnectivity = preciceInterface.requiresMeshConnectivityFor(asteInterface.meshName);
   const int  dim                 = preciceInterface.getMeshDimensions(asteInterface.meshName);


### PR DESCRIPTION
## Main changes of this PR

This PR changes the mapper of ASTE to abort if no mesh was found.
Currently, the executable SEGFAULTS, which is a bit dramatic.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).
