### PR TITLE
Make `run-all` script for examples more robust

### DIFF
--- a/examples/run-all.sh
+++ b/examples/run-all.sh
@@ -2,7 +2,7 @@
 set -e -u
 
 if ! command -v precice-aste-run &> /dev/null || ! command -v precice-aste-evaluate &> /dev/null; then
-    echo "Error: It seems that ASTE is not installed or not discoverable in your PATH."
+    echo "Error: It seems that ASTE is not installed or not discoverable in your PATH. See https://precice.org/tooling-aste.html#installation for more information."
     exit 1
 fi
 

--- a/examples/run-all.sh
+++ b/examples/run-all.sh
@@ -1,33 +1,56 @@
 #!/bin/bash
 set -e -u
 
-# Print the problmatic case and increase error count
-detect_error(){
-    echo "Error while running case ${array[1]}"
+# Get the absolute directory of where the script is located (execution from anywhere)
+script_dir=$(dirname "$(readlink -f "$0")")
+
+# Function to handle errors
+detect_error() {
+    echo "Error while running case $case_dir"
     err_count=$((err_count + 1))
 }
 
-echo "- Running all examples cases..."
-test_cases=$(find . -maxdepth 2 -mindepth 2 -name run.sh)
-number_of_cases=$(echo "$test_cases" | wc -w)
-echo "- There are $number_of_cases case(s) found..."
+# We only look for test cases one level lower since the mapping-tester generates additional run scripts
+run_test_cases() {
+    local base_dir="$1"
 
-# Initial directory and error count
-run_all_dir=$(pwd)
+    test_cases=$(find "$base_dir" -maxdepth 2 -mindepth 2 -name run.sh)
+
+    # Check if there are any cases
+    number_of_cases=$(echo "$test_cases" | wc -w)
+    if [ "$number_of_cases" -eq 0 ]; then
+        echo "No test cases found in $base_dir."
+        return
+    fi
+    echo "- Found $number_of_cases case(s) in $base_dir..."
+
+    for testcase in $test_cases; do
+        case_dir=$(dirname "$testcase")
+        echo "- Running test case in $case_dir ..."
+
+        # Change to the test case directory
+        cd "$case_dir"
+
+        # Run the test and check for errors
+        ./run.sh || detect_error
+
+        # Return to the original directory
+        cd "$base_dir"
+    done
+}
+
+echo "- Running all example cases from $script_dir..."
+
+# Initialize error count
 err_count=0
 
-# Run all cases
-for testcase in $test_cases; do
-    array=($(echo "$testcase" | tr "/" "\n"))
-    cd "${array[1]}"
-    echo "- Running test case ${array[1]}..."
-    ./run.sh || detect_error
-    cd "$run_all_dir"
-done
+# Run all test cases starting from the script's directory
+run_test_cases "$script_dir"
 
-if [  $err_count -eq 0 ]; then
+# Report results
+if [ "$err_count" -eq 0 ]; then
     echo "All tests passed"
 else
-    echo "$err_count out of $number_of_cases failed"
+    echo "$err_count test(s) failed."
     exit 1
 fi

--- a/examples/run-all.sh
+++ b/examples/run-all.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -u
 
+if ! command -v precice-aste-run &> /dev/null || ! command -v precice-aste-evaluate &> /dev/null; then
+    echo "Error: It seems that ASTE is not installed or not discoverable in your PATH."
+    exit 1
+fi
+
 # Get the absolute directory of where the script is located (execution from anywhere)
 script_dir=$(dirname "$(readlink -f "$0")")
 


### PR DESCRIPTION
## Main changes of this PR

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [x] I added a test to cover the proposed changes in our test suite.
* <del> I updated the documentation in `docs/README.md`. </del>
* <del>  I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).</del>

Related to #199 
<!-- add more questions/tasks if necessary -->
