### PR TITLE
Highlight dependency from preCICE more clear

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,14 @@ The core module, which interfaces with preCICE, is called `precice-aste-run` and
 
 The C++ core module of ASTE depends on a C++ compiler, `CMake`, `MPI`, `Boost`, `VTK` and `preCICE`. Many of these dependencies are similar to dependencies of preCICE itself. In particular, the C++ compiler, `CMake`, `MPI` and `Boost`. Have a look at the [corresponding preCICE documentation](https://precice.org/installation-source-dependencies.html) for required versions and on how to install these dependencies if needed. In addition, ASTE relies on `preCICE` (version >= 3.0) and the `VTK` library (version >= 7) to handle mesh files.
 
-Detailed installation instructions for the preCICE library are available in the preCICE [installation documentation](https://precice.org/installation-overview.html). On Ubuntu, e.g., [system packages](https://precice.org/installation-packages.html#ubuntu) are availble through [GitHub releases](https://github.com/precice/precice/releases) and can be installed through the package manager. The VTK library can be installed using the package manager directly (`libvtk<VERSION>-dev`), e.g., on Ubuntu
+Detailed installation instructions for the preCICE library are available in the preCICE [installation documentation](https://precice.org/installation-overview.html). On Ubuntu, e.g., [system packages](https://precice.org/installation-packages.html#ubuntu) are availble through [GitHub releases](https://github.com/precice/precice/releases) and can be installed through the package manager, e.g.,
+
+```bash
+wget https://github.com/precice/precice/releases/download/<VERSION>/libprecice<VERSION>.deb
+sudo apt install ./libprecice<VERSION>.deb
+```
+
+The VTK library can be installed using the package manager directly (`libvtk<VERSION>-dev`), e.g., on Ubuntu
 
 ```bash
 sudo apt install libvtk9-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,15 +19,9 @@ The core module, which interfaces with preCICE, is called `precice-aste-run` and
 
 ### Dependencies
 
-The C++ core module of ASTE uses similar dependencies as preCICE itself. In particular, ASTE requires a C++ compiler, `CMake`, `MPI` and `Boost`. Have a look at the [corresponding preCICE documentation](https://precice.org/installation-source-dependencies.html) for required versions and on how to install these dependencies if needed. In addition, ASTE relies on `preCICE` (version >= 3.0) and the `VTK` library (version >= 7) to handle mesh files.
+The C++ core module of ASTE depends on a C++ compiler, `CMake`, `MPI`, `Boost`, `VTK` and `preCICE`. Many of these dependencies are similar to dependencies of preCICE itself. In particular, the C++ compiler, `CMake`, `MPI` and `Boost`. Have a look at the [corresponding preCICE documentation](https://precice.org/installation-source-dependencies.html) for required versions and on how to install these dependencies if needed. In addition, ASTE relies on `preCICE` (version >= 3.0) and the `VTK` library (version >= 7) to handle mesh files.
 
-Detailed installation instructions for the preCICE library are available in the preCICE [installation documentation](https://precice.org/installation-overview.html). On [Ubuntu](https://precice.org/installation-packages.html#ubuntu), e.g., system packages are availble and can be downloaded from [GitHub releases](https://github.com/precice/precice/releases) and installed through the package manager
-
-```bash
-sudo apt install ./libprecice<VERSION>.deb
-```
-
-The VTK library can be installed using the package manager (`libvtk<VERSION>-dev`), e.g., on Ubuntu
+Detailed installation instructions for the preCICE library are available in the preCICE [installation documentation](https://precice.org/installation-overview.html). On Ubuntu, e.g., [system packages](https://precice.org/installation-packages.html#ubuntu) are availble through [GitHub releases](https://github.com/precice/precice/releases) and can be installed through the package manager. The VTK library can be installed using the package manager directly (`libvtk<VERSION>-dev`), e.g., on Ubuntu
 
 ```bash
 sudo apt install libvtk9-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,15 @@ The core module, which interfaces with preCICE, is called `precice-aste-run` and
 
 ### Dependencies
 
-The C++ core module of ASTE uses similar dependencies as preCICE itself. In particular, ASTE requires a C++ compiler, CMake, MPI and Boost. Have a look at the [corresponding preCICE documentation](https://precice.org/installation-source-dependencies.html) for required versions and on how to install these dependencies if needed. In addition, ASTE relies on preCICE (version >= 3.0) and the VTK library (version >= 7) in order to handle mesh files. The VTK library can be installed using the package manager (`libvtk<VERSION>-dev`), e.g., on Ubuntu
+The C++ core module of ASTE uses similar dependencies as preCICE itself. In particular, ASTE requires a C++ compiler, `CMake`, `MPI` and `Boost`. Have a look at the [corresponding preCICE documentation](https://precice.org/installation-source-dependencies.html) for required versions and on how to install these dependencies if needed. In addition, ASTE relies on `preCICE` (version >= 3.0) and the `VTK` library (version >= 7) to handle mesh files.
+
+Detailed installation instructions for the preCICE library are available in the preCICE [installation documentation](https://precice.org/installation-overview.html). On [Ubuntu](https://precice.org/installation-packages.html#ubuntu), e.g., system packages are availble and can be downloaded from [GitHub releases](https://github.com/precice/precice/releases) and installed through the package manager
+
+```bash
+sudo apt install ./libprecice<VERSION>.deb
+```
+
+The VTK library can be installed using the package manager (`libvtk<VERSION>-dev`), e.g., on Ubuntu
 
 ```bash
 sudo apt install libvtk9-dev


### PR DESCRIPTION
## Main changes of this PR

The dependency from preCICE was already listed before, but no instructions on how to get preCICE were included.
Closes #204 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I updated the documentation in `docs/README.md`.
* [x] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
