### PR TITLE
Add scoping support to gathering events

### DIFF
--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -49,15 +49,10 @@ def statsFromTimings(dir):
                         stats["globalTime"] = row[-1]
                     if row[0] == "initialize":
                         stats["initializeTime"] = row[-1]
-                    if row[0].startswith("initialize/map") and row[0].endswith(
-                        "computeMapping.FromA-MeshToB-Mesh"
-                    ):
-                        computeMappingName = row[0]
+                    parts = row[-1].split("/")
+                    if parts[0] == "initialize" and parts[-1].startswith("map") and parts[-1].endswith("computeMapping.FromA-MeshToB-Mesh"):
                         stats["computeMappingTime"] = row[-1]
-                    if row[0].startswith("advance/map") and row[0].endswith(
-                        "mapData.FromA-MeshToB-Mesh"
-                    ):
-                        mapDataName = row[0]
+                    if parts[0] == "advance" and parts[-1].startswith("map") and parts[-1].endswith("mapData.FromA-MeshToB-Mesh"):
                         stats["mapDataTime"] = row[-1]
         except BaseException:
             pass

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -49,10 +49,19 @@ def statsFromTimings(dir):
                         stats["globalTime"] = row[-1]
                     if row[0] == "initialize":
                         stats["initializeTime"] = row[-1]
-                    parts = row[-1].split("/")
-                    if parts[0] == "initialize" and parts[-1].startswith("map") and parts[-1].endswith("computeMapping.FromA-MeshToB-Mesh"):
+                    parts = row[0].split("/")
+                    event = parts[-1]
+                    if (
+                        parts[0] == "initialize"
+                        and event.startswith("map")
+                        and event.endswith("computeMapping.FromA-MeshToB-Mesh")
+                    ):
                         stats["computeMappingTime"] = row[-1]
-                    if parts[0] == "advance" and parts[-1].startswith("map") and parts[-1].endswith("mapData.FromA-MeshToB-Mesh"):
+                    if (
+                        parts[0] == "advance"
+                        and event.startswith("map")
+                        and event.endswith("mapData.FromA-MeshToB-Mesh")
+                    ):
                         stats["mapDataTime"] = row[-1]
         except BaseException:
             pass


### PR DESCRIPTION
## Main changes of this PR

This PR changes gatherstats to use scopes for extracting timings from the profiling data, making it robust against the introduction of additional scopes in between.

Related to https://github.com/precice/precice/pull/2066

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).