### PR TITLE
Cache VTK build in ASTE CI

### DIFF
--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -19,6 +19,9 @@ jobs:
     container:
       image: precice/ci-aste:latest
       options: --shm-size=2gb
+    defaults:
+      run:
+        shell: "bash --login -eo pipefail {0}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -13,11 +13,44 @@ concurrency:
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:
+  vtk:
+    name: Build VTK from source
+    runs-on: ubuntu-latest
+    container:
+      image: precice/precice:nightly
+      options: --shm-size=2gb
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
+    steps:
+      - name: Check VTK cache
+        id: cache-vtk
+        uses: actions/cache@v4
+        with:
+          key: ${{ os.runner }}-aste-vtk
+          path: |
+            /usr/local/include/vtk-*/
+            /usr/local/lib/libvtk*
+            /usr/local/lib/cmake/vtk-*/
+            /usr/local/bin/vtk*
+            /usr/local/lib/python*/site-packages/vtk.py
+            /usr/local/lib/python*/site-packages/vtkmodules/*
+            /etc/profile.d/99-vtk.sh
+      - name: Build VTK
+        if: steps.cache-vtk.outputs.cache-hit != 'true'
+        run: |
+          git clone https://gitlab.kitware.com/vtk/vtk.git && cd vtk
+          git checkout v9.3.0
+          mkdir build && cd build
+          cmake -DVTK_WRAP_PYTHON="ON" -DVTK_USE_MPI="ON" -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build . && cmake --install .
+          echo 'export PYTHONPATH="${PYTHONPATH}:/usr/local/lib/python3.10/site-packages/"' > /etc/profile.d/99-vtk.sh
+
   build:
+    needs: vtk
     name: ${{ format('{0} {1}', matrix.CXX, matrix.TYPE) }}
     runs-on: ubuntu-latest
     container:
-      image: precice/ci-aste:latest
+      image: precice/precice:nightly
       options: --shm-size=2gb
     defaults:
       run:
@@ -33,11 +66,23 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: "Yes"
       CMAKE_BUILD_PARALLEL_LEVEL: 4
     steps:
+      - name: Restore VTK from cache
+        uses: actions/cache@v4
+        with:
+          fail-on-cache-miss: true
+          key: ${{ os.runner }}-aste-vtk
+          path: |
+            /usr/local/include/vtk-*/
+            /usr/local/lib/libvtk*
+            /usr/local/lib/cmake/vtk-*/
+            /usr/local/bin/vtk*
+            /usr/local/lib/python*/site-packages/vtk.py
+            /usr/local/lib/python*/site-packages/vtkmodules/*
+            /etc/profile.d/99-vtk.sh
       - name: setup system
         run: |
           apt-get -y update && apt-get -y upgrade
-          apt-get install -y python3-pip pkg-config time clang
-          pip3 install --upgrade pip
+          apt-get install -qq -y python3-pip python3-jinja2 python3-scipy python3-sympy libmetis-dev time clang
       - uses: actions/checkout@v4
       - name: install example dependencies
         run: |

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -32,6 +32,7 @@ jobs:
             /usr/local/lib/libvtk*
             /usr/local/lib/cmake/vtk-*/
             /usr/local/bin/vtk*
+            /usr/local/bin/pvtkpython
             /usr/local/lib/python*/site-packages/vtk.py
             /usr/local/lib/python*/site-packages/vtkmodules/*
             /etc/profile.d/99-vtk.sh
@@ -76,6 +77,7 @@ jobs:
             /usr/local/lib/libvtk*
             /usr/local/lib/cmake/vtk-*/
             /usr/local/bin/vtk*
+            /usr/local/bin/pvtkpython
             /usr/local/lib/python*/site-packages/vtk.py
             /usr/local/lib/python*/site-packages/vtkmodules/*
             /etc/profile.d/99-vtk.sh

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: setup system
         run: |
           apt-get -y update && apt-get -y upgrade
-          apt-get install -y python3-pip pkg-config time
+          apt-get install -y python3-pip pkg-config time clang
           pip3 install --upgrade pip
       - uses: actions/checkout@v4
       - name: install example dependencies

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -26,7 +26,7 @@ jobs:
         id: cache-vtk
         uses: actions/cache@v4
         with:
-          key: ${{ os.runner }}-aste-vtk
+          key: ${{ runner.os }}-aste-vtk
           path: |
             /usr/local/include/vtk-*/
             /usr/local/lib/libvtk*
@@ -70,7 +70,7 @@ jobs:
         uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
-          key: ${{ os.runner }}-aste-vtk
+          key: ${{ runner.os }}-aste-vtk
           path: |
             /usr/local/include/vtk-*/
             /usr/local/lib/libvtk*

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -14,10 +14,18 @@ concurrency:
 
 jobs:
   build:
+    name: ${{ format('{0} {1}', matrix.CXX, matrix.TYPE) }}
     runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    timeout-minutes: 80
+    container:
+      image: precice/ci-aste:latest
+      options: --shm-size=2gb
+    strategy:
+      fail-fast: false
+      matrix:
+        CXX: ["clang++", "g++"]
+        TYPE: ["Debug", "Release"]
     env:
+      CXX: ${{ matrix.CXX }}
       CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
       CTEST_OUTPUT_ON_FAILURE: "Yes"
     steps:
@@ -26,50 +34,21 @@ jobs:
           apt-get -y update && apt-get -y upgrade
           apt-get install -y python3-pip pkg-config time
           pip3 install --upgrade pip
-      - name: install VTK
-        run: |
-          git clone https://gitlab.kitware.com/vtk/vtk.git && cd vtk
-          git checkout v9.3.0
-          mkdir build && cd build
-          cmake -DVTK_WRAP_PYTHON="ON" -DVTK_USE_MPI="ON" -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build . -j 2 && cmake --install .
-          echo "PYTHONPATH=/usr/local/lib/python3.10/site-packages/:${PYTHONPATH}" >> $GITHUB_ENV
-          cd
       - uses: actions/checkout@v4
       - name: install example dependencies
         run: |
           python3 -m pip install -r requirements.txt
-      - name: prepare directories
+      - name: prepare build directory
         run: |
-          mkdir build_gcc build_clang
-      - name: build aste gcc
-        working-directory: build_gcc
-        env:
-          CC: gcc
-          CXX: g++
+          mkdir build
+      - name: build aste
+        working-directory: build
         run: |
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} ..
           cmake --build .
       - name: Adjust user rights
         run: chown -R precice .
-      - name: run test gcc
-        working-directory: build_gcc
-        run: |
-          su -c "ctest" precice
-      - name: install clang
-        run: |
-          apt-get -y install clang
-      - name: build aste clang
-        working-directory: build_clang
-        env:
-          CC: clang
-          CXX: clang++
-        run: |
-          cmake ..
-          cmake --build .
-      - name: Adjust user rights
-        run: chown -R precice .
-      - name: run test clang
-        working-directory: build_clang
+      - name: run test
+        working-directory: build
         run: |
           su -c "ctest" precice

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -31,6 +31,7 @@ jobs:
       CXX: ${{ matrix.CXX }}
       CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
       CTEST_OUTPUT_ON_FAILURE: "Yes"
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
     steps:
       - name: setup system
         run: |


### PR DESCRIPTION
## Main changes of this PR

This PR uses the new ASTE CI image https://hub.docker.com/r/precice/ci-aste which is based on `precice/precice:nightly` and installs a _working_ version of VTK from source.

https://github.com/precice/ci-images/blob/master/ci-aste.dockerfile

## TODO

- [x] ~~keep or~~ clean ci-image

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
