### PR TITLE
Extend instead of overrride PATH in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16.3)
+cmake_minimum_required (VERSION 3.22)
 
 project(ASTE VERSION 3.3.0)
 
@@ -135,7 +135,7 @@ foreach(example IN LISTS _examples)
   set_tests_properties(aste.example.${example} aste.example.${example}.setup
     PROPERTIES
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples/${example}"
-    ENVIRONMENT "PATH=$ENV{PATH}:${CMAKE_BINARY_DIR}"
+    ENVIRONMENT_MODIFICATION "PATH=path_list_append:${CMAKE_BINARY_DIR}"
     LABELS example
     RUN_SERIAL ON)
 endforeach()

--- a/changelog-entries/215.md
+++ b/changelog-entries/215.md
@@ -1,0 +1,1 @@
+- Changed the minimum required CMake version to 3.22.


### PR DESCRIPTION
## Main changes of this PR

This allows to change PATH after configuring and building ASTE.
It also allows to use a venv created afterward building.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
