### PR TITLE
Autoupdate python scripts in binary dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,9 @@ else ()
     )
 endif()
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-partition      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-join           DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/precice-aste-evaluate      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(src/precice-aste-partition . COPYONLY)
+configure_file(src/precice-aste-join . COPYONLY)
+configure_file(src/precice-aste-evaluate . COPYONLY)
 
 include(GNUInstallDirs)
 install(TARGETS precice-aste-run DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
## Main changes of this PR

Uses CMake's `configure_file` to copy python scripts in `src/` to the binary dir.
The buildsystem now triggers a reconfiguration when one of these scripts is changed, which keeps the scripts in the binary directory up2date.

This avoids having to manually trigger `cmake .` whenever one changes a script, which is very useful for quick changes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
