### PR TITLE
more strict file names / allow numbers in mesh file prefix

### DIFF
--- a/changelog-entries/220.md
+++ b/changelog-entries/220.md
@@ -1,0 +1,1 @@
+- Check strict naming scheme for meshes in replay mode, mesh file names must include `.dt<N>` with `<N>` the coupling iteration. This is to allow numbers elsewhere in the file name or path.

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -201,6 +201,11 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
   }
 
   auto asteInterface = asteConfiguration.asteInterfaces.front();
+  if (asteInterface.meshes.empty()) {
+    ASTE_ERROR << "ERROR: Could not find meshes for name: " << meshname;
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
   ASTE_INFO << "Loading mesh from " << asteInterface.meshes.front().filename();
   const bool requireConnectivity = preciceInterface.requiresMeshConnectivityFor(asteInterface.meshName);
   const int  dim                 = preciceInterface.getMeshDimensions(asteInterface.meshName);

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -67,7 +67,8 @@ void aste::runReplayMode(const aste::ExecutionContext &context, const std::strin
 
   ASTE_DEBUG << "Looking for dt = " << asteConfiguration.startdt;
   for (const auto &mesh : asteConfiguration.asteInterfaces.front().meshes) {
-    if (mesh.filename().find(std::to_string(asteConfiguration.startdt)) == std::string::npos)
+    auto meshfilename = std::filesystem::path(mesh.filename()).filename().string();
+    if (meshfilename.find(".dt" + std::to_string(asteConfiguration.startdt)) == std::string::npos)
       round++;
     else
       break;
@@ -200,11 +201,6 @@ void aste::runMapperMode(const aste::ExecutionContext &context, const OptionMap 
   }
 
   auto asteInterface = asteConfiguration.asteInterfaces.front();
-  if (asteInterface.meshes.empty()) {
-    ASTE_ERROR << "ERROR: Could not find meshes for name: " << meshname;
-    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-  }
-
   ASTE_INFO << "Loading mesh from " << asteInterface.meshes.front().filename();
   const bool requireConnectivity = preciceInterface.requiresMeshConnectivityFor(asteInterface.meshName);
   const int  dim                 = preciceInterface.getMeshDimensions(asteInterface.meshName);


### PR DESCRIPTION
## Main changes of this PR

Replay mode currently doesn't allow numbers in the mesh file prefix since the code is looking for the string `"1"` (if startdt = 1) anywhere in the file name, including the path. If the data files are `directory1/mesh.init.vtk` and `directory1/mesh.dt1.vtk`, the search picks `directory1/mesh.init.vtk` as the mesh for the first time step and complains about missing `0` or `init` file if initialization is required. (Error message: `Starting from dt =1 but previous timestep ".init" or 0 was not found. Please make sure the relevant Mesh exists.`) I think this only actually a problem if data initialization is enabled, otherwise the sorting of the list of mesh file names hides the bug.

With this change, the code is looking for `".dt1"` instead, and only in the actual file name, not in the path.

Pro: Allow numbers in the mesh prefix path, e.g. resolution of the mesh, versions, dates, etc.

Con: Someone might rely on a less strict format, i.e. using `mesh1.vtk` as file names. The documentation doesn't explicitly forbid this, but it does talk about using the meshes generated by precice export. I guess the check could be relaxed a bit by checking for `1` instead of `dt1`, but not including the path.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`. => I think the documentation already covers this
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine). => tutorials use meshes generated by precice export, so it's fine

Can add a test and changelog on request, not sure this small change requires it.
