### PR TITLE
Add configurable seed for partitioning

### DIFF
--- a/changelog-entries/214.md
+++ b/changelog-entries/214.md
@@ -1,0 +1,1 @@
+- Added configurable partitioning algorithm to mapping tester.

--- a/changelog-entries/224.md
+++ b/changelog-entries/224.md
@@ -1,0 +1,1 @@
+- Changed partitioning algorihm to use a fixed seed which can be passed via the `--seed` flag. This makes partitioning deterministic.

--- a/examples/mapping_tester/setup-test.json
+++ b/examples/mapping_tester/setup-test.json
@@ -1,6 +1,7 @@
 {
   "general": {
     "function": "0.78 + cos(10*(x+y+z))",
+    "partitioning": "topology",
     "ranks": {
       "A": [
         2

--- a/src/metisAPI.cpp
+++ b/src/metisAPI.cpp
@@ -1,16 +1,15 @@
 #include <iostream>
 #include <metis.h>
 #include <vector>
-extern "C" void partitionMetis(idx_t cell_count, idx_t point_count, idx_t *cellptr, idx_t *celldata, idx_t nparts, idx_t *point_partition);
+extern "C" void partitionMetis(idx_t cell_count, idx_t point_count, idx_t *cellptr, idx_t *celldata, idx_t nparts, idx_t seed, idx_t *point_partition);
 extern "C" int  typewidth();
 
-void partitionMetis(idx_t cell_count, idx_t point_count, idx_t *cellptr, idx_t *celldata, idx_t nparts, idx_t *point_partition)
+void partitionMetis(idx_t cell_count, idx_t point_count, idx_t *cellptr, idx_t *celldata, idx_t nparts, idx_t seed, idx_t *point_partition)
 {
   idx_t options[METIS_NOPTIONS];
   METIS_SetDefaultOptions(options);
   // Make it deterministic
-  // TODO: Pass via interface
-  options[METIS_OPTION_SEED] = 2025;
+  options[METIS_OPTION_SEED] = seed;
   std::vector<idx_t> cell_partition(cell_count);
   idx_t              objval;
   // TODO: Check return value of the function (and potentially add an assert)

--- a/src/precice-aste-partition
+++ b/src/precice-aste-partition
@@ -85,13 +85,11 @@ class MeshPartitioner:
     def run(args) -> None:
         logger = MeshPartitioner.get_logger()
         mesh_name = args.in_meshname
-        algorithm = args.algorithm
-        if not algorithm:
-            logger.info('No algorithm given. Defaulting to "meshfree"')
-            algorithm = "meshfree"
         mesh = MeshPartitioner.read_mesh(mesh_name)
         if args.numparts > 1:
-            part = MeshPartitioner.partition(mesh, args.numparts, algorithm)
+            part = MeshPartitioner.partition(
+                mesh, args.numparts, args.algorithm, args.seed
+            )
         else:
             if args.directory:
                 # Get the absolute directory where we want to store the mesh
@@ -160,11 +158,21 @@ class MeshPartitioner:
             "-a",
             dest="algorithm",
             choices=["meshfree", "topology", "uniform"],
+            default="meshfree",
             help="""Change the algorithm used for determining a partition.
                 A meshfree algorithm works on arbitrary meshes without needing topological information.
                 A topology-based algorithm needs topology information
                 and is therefore useless on point clouds.
                 A uniform algorithm will assume a uniform 2d mesh laid out somehow in 3d and partition accordingly.""",
+        )
+        parser.add_argument(
+            "--seed",
+            "-s",
+            type=int,
+            default=2025,  # arbitrary default seed
+            help="""Seed to pass on to partitioning algorithms which may use it to end up with deterministic behaviour.
+            Not all algorithms may use it though.
+            """,
         )
         parser.add_argument(
             "--log",
@@ -192,30 +200,36 @@ class MeshPartitioner:
         return logging.getLogger("---[ASTE-Partition]")
 
     @staticmethod
-    def partition(mesh: Mesh, numparts: int, algorithm):
+    def partition(mesh: Mesh, numparts: int, algorithm: str, seed: int):
         """
         Partitions a mesh using METIS or kmeans. This does not call METIS directly,
         but instead uses a small C++ Wrapper around shared library libmetisAPI for convenience.
         This shared library must be provided if this function should be called.
         """
         if algorithm == "meshfree":
-            return MeshPartitioner.partition_kmeans(mesh, numparts)
+            return MeshPartitioner.partition_kmeans(mesh, numparts, seed)
         elif algorithm == "topology":
-            return MeshPartitioner.partition_metis(mesh, numparts)
+            return MeshPartitioner.partition_metis(mesh, numparts, seed)
         elif algorithm == "uniform":
             labels = MeshPartitioner.partition_uniform(mesh, numparts)
             if labels is None:
-                return MeshPartitioner.partition(mesh, numparts, "meshfree")
+                return MeshPartitioner.partition(mesh, numparts, "meshfree", seed)
             return labels
 
     @staticmethod
-    def partition_kmeans(mesh: Mesh, numparts: int):
+    def partition_kmeans(mesh: Mesh, numparts: int, seed: int):
         """Partitions a mesh using k-means. This is a meshfree algorithm and requires scipy"""
+        import scipy
         from scipy.cluster.vq import kmeans2
 
         points = np.copy(mesh.points)
         points = MeshPartitioner.reduce_dimension(points)
-        _, label = kmeans2(points, numparts)
+        # scipy 1.15 renamed seed to rng
+        major, minor = map(int, scipy.__version__.split(".")[:2])
+        if major == 1 and minor < 15:
+            _, label = kmeans2(points, numparts, rng=seed)
+        else:
+            _, label = kmeans2(points, numparts, seed=seed)
         return label
 
     @staticmethod
@@ -296,7 +310,7 @@ class MeshPartitioner:
             return mesh[:, :-1]
 
     @staticmethod
-    def partition_metis(mesh: Mesh, numparts: int):
+    def partition_metis(mesh: Mesh, numparts: int, seed: int):
         """
         Partitions a mesh using METIS. This does not call METIS directly,
         but instead uses a small C++ Wrapper libmetisAPI.so for convenience.
@@ -339,8 +353,9 @@ class MeshPartitioner:
         partition = (idx_t * len(mesh.points))()
         cell_ptr = (idx_t * len(cellPtr))(*cellPtr)
         cell_data = (idx_t * len(cellData))(*cellData)
+        the_seed = idx_t(seed)
         libmetis.partitionMetis(
-            cell_count, point_count, cell_ptr, cell_data, num_parts, partition
+            cell_count, point_count, cell_ptr, cell_data, num_parts, seed, partition
         )
         return np.ctypeslib.as_array(partition)
 

--- a/tools/mapping-tester/preparemeshes.py
+++ b/tools/mapping-tester/preparemeshes.py
@@ -111,6 +111,10 @@ def main(argv):
         print('Warning: outdir "{}" already exisits.'.format(outdir))
     meshdir = os.path.join(outdir, "meshes")
     function = setup["general"]["function"]
+    if "partitioning" not in setup["general"]:
+        print(
+            "You haven't specified a partitioning algorihm in the general section of the setup.json. This defaults to meshfree, which uses a non-deterministic k-means clusterting. Partitionings will be non-reproducible."
+        )
     algorithm = setup["general"].get("partitioning", "meshfree")
 
     partitions = set(

--- a/tools/mapping-tester/preparemeshes.py
+++ b/tools/mapping-tester/preparemeshes.py
@@ -64,7 +64,7 @@ def prepareMainMesh(meshdir, name, file, function, force=False):
     )
 
 
-def preparePartMesh(meshdir, name, p, force=False):
+def preparePartMesh(meshdir, name, p, force, algorithm):
 
     if p == 1:
         return
@@ -91,7 +91,7 @@ def preparePartMesh(meshdir, name, p, force=False):
             "--mesh",
             mainMesh,
             "--algorithm",
-            "topology",
+            algorithm,
             "-o",
             partMesh,
             "--directory",
@@ -111,6 +111,7 @@ def main(argv):
         print('Warning: outdir "{}" already exisits.'.format(outdir))
     meshdir = os.path.join(outdir, "meshes")
     function = setup["general"]["function"]
+    algorithm = setup["general"].get("partitioning", "meshfree")
 
     partitions = set(
         [int(rank) for pranks in setup["general"]["ranks"].values() for rank in pranks]
@@ -128,7 +129,7 @@ def main(argv):
         prepareMainMesh(meshdir, name, file, function, args.force)
 
         for p in partitions:
-            preparePartMesh(meshdir, name, p, args.force)
+            preparePartMesh(meshdir, name, p, args.force, algorithm)
 
     return 0
 

--- a/tools/mapping-tester/preparemeshes.py
+++ b/tools/mapping-tester/preparemeshes.py
@@ -111,11 +111,14 @@ def main(argv):
         print('Warning: outdir "{}" already exisits.'.format(outdir))
     meshdir = os.path.join(outdir, "meshes")
     function = setup["general"]["function"]
-    if "partitioning" not in setup["general"]:
+    algorithm = setup["general"].get("partitioning", "meshfree")
+
+    if "partitioning" in setup["general"]:
+        print(f"Using partitioning algorithm {algorithm}")
+    else:
         print(
             "You haven't specified a partitioning algorihm in the general section of the setup.json. This defaults to meshfree, which uses a non-deterministic k-means clusterting. Partitionings will be non-reproducible."
         )
-    algorithm = setup["general"].get("partitioning", "meshfree")
 
     partitions = set(
         [int(rank) for pranks in setup["general"]["ranks"].values() for rank in pranks]


### PR DESCRIPTION
## Main changes of this PR

Based on #214

This PR adds a configurable seed to `precice-aste-partition` which defaults to the random number 2025.
This seed is then passed on to the metis for topology and scipy kmean2 for meshfree, making them deterministic.

Therefore, to change the partitioning, one now has to manually pass a different seed.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
