### PR TITLE
Add mapping-tester aggregate script

### DIFF
--- a/examples/mapping_tester_runtime/reference-aggregated.csv
+++ b/examples/mapping_tester_runtime/reference-aggregated.csv
@@ -1,0 +1,3 @@
+mapping,constraint,mesh A,mesh B,ranks A,ranks B,computeMappingTime,globalTime,initializeTime,mapDataTime,peakMemA,peakMemB
+nn,consistent,coarse_mesh,fine_mesh,2,2,968.0,117537.33333333333,89569.66666666667,1.6666666666666667,116752.0,116426.66666666667
+tps,consistent,coarse_mesh,fine_mesh,2,2,316.6666666666667,143683.0,115327.33333333333,483.6666666666667,115870.66666666667,129608.0

--- a/examples/mapping_tester_runtime/run.sh
+++ b/examples/mapping_tester_runtime/run.sh
@@ -18,4 +18,8 @@ export ASTE_B_MPIARGS=""
 
 python3 "${MAPPING_TESTER}/repeat.py" 5 --file "test-statistics{}.csv"
 
+python3 "${MAPPING_TESTER}/aggregate.py" test-statistics.csv mean -x
+
 python3 "${MAPPING_TESTER}/compare.py" reference-statistics.csv test-statistics.csv
+
+python3 "${MAPPING_TESTER}/compare.py" reference-aggregated.csv aggregated.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jinja2
+matplotlib
 numpy
 polars
 scipy

--- a/tools/mapping-tester/README.md
+++ b/tools/mapping-tester/README.md
@@ -68,7 +68,7 @@ This generates various statistics for each case and aggregates them into a singl
 
 ## Runtime measurements
 
-Runtime measurements require multiple samples to get meaningful results.
+Runtime measurements require multiple runs to get meaningful results.
 For this purpose the, `repeat.py` script reruns the above running, postprocessing, and gathering steps for the given amount of repetitions.
 The N output CSV files can then be aggregated using `aggregate.py`.
 

--- a/tools/mapping-tester/README.md
+++ b/tools/mapping-tester/README.md
@@ -66,6 +66,12 @@ Use the saved time to cite the project.
 
 This generates various statistics for each case and aggregates them into a single CSV file.
 
+## Runtime measurements
+
+Runtime measurements require multiple samples to get meaningful results.
+For this purpose the, `repeat.py` script reruns the above running, postprocessing, and gathering steps for the given amount of repetitions.
+The N output CSV files can then be aggregated using `aggregate.py`.
+
 ## plotconv.py
 
 This reads the stats file, averages the runs and plots various convergence statistics.

--- a/tools/mapping-tester/aggregate.py
+++ b/tools/mapping-tester/aggregate.py
@@ -1,0 +1,74 @@
+#!python3
+
+import argparse
+import pathlib
+
+import numpy as np
+import polars as pl
+
+
+def parseArguments():
+    parser = argparse.ArgumentParser(
+        description="Aggregates statistics of multiple runs. See mapping-tester repreat.py"
+    )
+    parser.add_argument(
+        "file",
+        type=pathlib.Path,
+        help="Statistics file to aggregate runs on",
+    )
+    parser.add_argument(
+        "kind",
+        choices=["mean", "median", "variance"],
+        help="Kind of aggregation",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude-min-max",
+        dest="exclude",
+        action="store_true",
+        help="Remove min and max from the data set before aggregating.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="aggregated.csv",
+        type=pathlib.Path,
+        help="Statistics file write the aggregated results to.",
+    )
+    return parser.parse_args()
+
+
+def trim(series: pl.Series):
+    return series.sort()[1:-1]
+
+
+def run(file: pathlib.Path, kind: str, exclude: bool, dest: pathlib.Path):
+
+    df = pl.read_csv(file).drop("run")
+
+    # returns a lambda that creates a pl.Exception for a given column name
+    func = {
+        "median": lambda c: pl.col(c).median(),
+        "mean": lambda c: (
+            pl.col(c).map_batches(trim).mean() if exclude else pl.col(c).mean()
+        ),
+        "variance": lambda c: (
+            pl.col(c).map_batches(trim).var() if exclude else pl.col(c).var()
+        ),
+    }[kind]
+
+    case = ["mapping", "constraint", "mesh A", "mesh B", "ranks A", "ranks B"]
+    df = df.group_by(case).agg([func(c) for c in df.columns if c not in case])
+
+    print(f"Writing output to {dest}")
+    df.write_csv(dest)
+
+
+def main():
+    args = parseArguments()
+    assert args.file.exists()
+    run(args.file, args.kind, args.exclude, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Main changes of this PR

Based on #226

This PR adds a script which aggregates a file containing multiple runs.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).
