### PR TITLE
Partial pathlib port

### DIFF
--- a/src/precice-aste-join
+++ b/src/precice-aste-join
@@ -3,7 +3,7 @@ import argparse
 import json
 import logging
 import os
-import os.path
+import pathlib
 
 import vtk
 
@@ -54,6 +54,7 @@ class MeshJoiner:
             "--recovery",
             dest="recovery",
             help="The path to the recovery file to fully recover it's state.",
+            type=pathlib.Path,
         )
         parser.add_argument(
             "--numparts",
@@ -68,6 +69,7 @@ class MeshJoiner:
             dest="directory",
             default=None,
             help="Directory for output files (optional)",
+            type=pathlib.Path,
         )
         parser.add_argument(
             "--log",
@@ -110,10 +112,17 @@ class MeshJoiner:
         num_points = joined_mesh.GetNumberOfPoints()
         num_cells = joined_mesh.GetNumberOfCells()
         logger.info(f"Final mesh contains {num_points} points, {num_cells} cells")
-        MeshJoiner.write_mesh(joined_mesh, out_meshname, args.directory)
+
+        filename = (
+            pathlib.Path(args.directory, out_meshname)
+            if args.directory
+            else pathlib.Path(out_meshname)
+        )
+
+        MeshJoiner.write_mesh(joined_mesh, filename)
 
     @staticmethod
-    def read_meshes(prefix: str, partitions=None, recovery_path=None):
+    def read_meshes(prefix: str, partitions: int, recovery_path: pathlib.Path):
         """
         Reads meshes with given prefix.
         """
@@ -126,7 +135,7 @@ class MeshJoiner:
         if partitions == 0:
             raise PartitionError("No partitions found")
 
-        if os.path.exists(recovery_path):
+        if recovery_path.is_file():
             logger.info("Recovery data found. Full recovery will be executed")
             return MeshJoiner.join_mesh_recovery(prefix, partitions, recovery_path)
         else:
@@ -213,12 +222,14 @@ class MeshJoiner:
         return joined_mesh
 
     @staticmethod
-    def join_mesh_recovery(prefix: str, partitions: int, recovery_path: str):
+    def join_mesh_recovery(prefix: str, partitions: int, recovery_path: pathlib.Path):
         """
         Partition merge with full recovery
 
         This recovers the original mesh.
         """
+        assert recovery_path.is_file()
+
         logger = MeshJoiner.get_logger()
         logger.info("Starting full mesh recovery")
         recovery = json.load(open(recovery_path, "r"))
@@ -335,29 +346,24 @@ class MeshJoiner:
         """
         detected = 0
         while True:
-            partition_file = prefix + "_" + str(detected) + ".vtu"
-            if not os.path.isfile(partition_file):
+            partition_file = pathlib.Path(f"{prefix}_{detected}.vtu")
+            if not partition_file.is_file():
                 break
             detected += 1
         return detected
 
     @staticmethod
-    def write_mesh(meshfile, filename, directory=None):
+    def write_mesh(meshfile, filename: pathlib.Path):
+        filename.parent.mkdir(exist_ok=True, parents=True)
 
-        filename = os.path.basename(os.path.normpath(filename))
-        if directory:
-            directory = os.path.abspath(directory)
-            os.makedirs(directory, exist_ok=True)
-            filename = os.path.join(directory, filename)
-
-        extension = os.path.splitext(filename)[1]
+        extension = filename.suffix
         if extension == ".vtk":  # VTK Legacy format
             writer = vtk.vtkUnstructuredGridWriter()
             writer.SetFileTypeToBinary()
         elif extension == ".vtu":  # VTK XML Unstructured Grid format
             writer = vtk.vtkXMLUnstructuredGridWriter()
         else:
-            raise ExtensionError("Unknown File extension: " + extension)
+            raise ExtensionError(f"Unknown File extension: {extension}")
         writer.SetFileName(filename)
         writer.SetInputData(meshfile)
         writer.Write()

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -2,9 +2,9 @@
 
 import argparse
 import csv
-import glob
 import json
 import os
+import pathlib
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
@@ -16,6 +16,7 @@ def parseArguments(args):
         "--outdir",
         default="cases",
         help="Directory to generate the test suite in.",
+        type=pathlib.Path,
     )
     parser.add_argument(
         "-f",
@@ -36,14 +37,17 @@ def run_checked(args):
     r.check_returncode()
 
 
-def timingStats(dir):
-    assert os.path.isdir(dir)
+def timingStats(dir: pathlib.Path):
+    assert dir.is_dir()
     assert (
         os.system("command -v precice-profiling > /dev/null") == 0
     ), 'Could not find the profiling tool "precice-profiling", which is part of the preCICE installation.'
-    event_dir = os.path.join(dir, "precice-profiling")
-    json_file = os.path.join(dir, "profiling.json")
-    timings_file = os.path.join(dir, "timings.csv")
+    event_dir = dir / "precice-profiling"
+    json_file = dir / "profiling.json"
+    timings_file = dir / "timings.csv"
+
+    if not event_dir.is_dir():
+        return {}
 
     try:
         subprocess.run(
@@ -56,9 +60,8 @@ def timingStats(dir):
             check=True,
             capture_output=True,
         )
-        file = timings_file
         stats = {}
-        with open(file, "r") as csvfile:
+        with open(timings_file, "r") as csvfile:
             timings = csv.reader(csvfile)
             for row in timings:
                 if row[0] == "_GLOBAL":
@@ -84,13 +87,13 @@ def timingStats(dir):
         return {}
 
 
-def memoryStats(dir):
-    assert os.path.isdir(dir)
+def memoryStats(dir: pathlib.Path):
+    assert dir.is_dir()
     stats = {}
     for P in "A", "B":
-        memfile = os.path.join(dir, f"memory-{P}.log")
+        memfile = dir / f"memory-{P}.log"
         total = 0
-        if os.path.isfile(memfile):
+        if memfile.is_file():
             try:
                 with open(memfile, "r") as file:
                     total = sum([float(e) / 1.0 for e in file.readlines()])
@@ -101,23 +104,22 @@ def memoryStats(dir):
     return stats
 
 
-def mappingStats(dir):
-    globber = os.path.join(dir, "*.stats.json")
-    statFiles = list(glob.iglob(globber))
-    if len(statFiles) == 0:
+def mappingStats(dir: pathlib.Path):
+    statFiles = list(dir.glob("*.stats.json"))
+    if not statFiles:
         return {}
 
     statFile = statFiles[0]
-    assert os.path.exists(statFile)
+    assert statFile.is_file()
     with open(statFile, "r") as jsonfile:
         return dict(json.load(jsonfile))
 
 
-def gatherCaseStats(casedir):
-    assert os.path.exists(casedir)
-    parts = os.path.normpath(casedir).split(os.sep)
-    assert len(parts) >= 5
-    mapping, constraint, meshes, ranks = parts[-4:]
+def gatherCaseStats(casedir: pathlib.Path):
+    assert casedir.is_dir()
+    parts = [casedir.name] + [p.name for p in casedir.parents]
+    assert len(parts) >= 4
+    ranks, meshes, constraint, mapping = parts[:4]
     meshA, meshB = meshes.split("-")
     ranksA, ranksB = ranks.split("-")
 
@@ -138,12 +140,16 @@ def gatherCaseStats(casedir):
 def main(argv):
     args = parseArguments(argv[1:])
 
-    globber = os.path.join(args.outdir, "**", "done")
-    cases = [os.path.dirname(path) for path in glob.iglob(globber, recursive=True)]
+    cases = [d.parent for d in args.outdir.rglob("done")]
+
+    if not cases:
+        print(f"No cases found in {args.outdir.absolute()}")
+        return 1
+
     allstats = []
 
     def wrapper(case):
-        print("Found: " + os.path.relpath(case, args.outdir))
+        print(f"Found: {case.relative_to(args.outdir)}")
         return gatherCaseStats(case)
 
     with ThreadPoolExecutor() as pool:

--- a/tools/mapping-tester/generate.py
+++ b/tools/mapping-tester/generate.py
@@ -2,7 +2,7 @@
 
 import argparse
 import json
-import os
+import pathlib
 import sys
 
 from jinja2 import Template
@@ -88,21 +88,7 @@ def getCaseFolders(case):
     ]
 
 
-def caseToSortable(case):
-    parts = case.split(os.path.sep)
-    kind = parts[0]
-    mesha, meshb = map(float, parts[-2].split("-"))
-
-    kindCost = 0
-    if kind.startswith("gaussian"):
-        kindCost = 1
-    elif kind.startswith("tps"):
-        kindCost = 2
-
-    return (kindCost, -mesha, -meshb)
-
-
-def createMasterRunScripts(casemap, dir, exit):
+def createMasterRunScripts(casemap, dir: pathlib.Path, exit):
     common = [
         "#!/bin/bash",
         "",
@@ -112,60 +98,46 @@ def createMasterRunScripts(casemap, dir, exit):
     ]
 
     # Generate master runner script
-    if exit:
-        content = common + [
-            "${RUNNER} " + os.path.join(case, "runall.sh || exit 1")
-            for case in casemap.keys()
-        ]
-    else:
-        content = common + [
-            "${RUNNER} " + os.path.join(case, "runall.sh") for case in casemap.keys()
-        ]
+    content = common + [
+        f"${{RUNNER}} { case / 'runall.sh' }" + " || exit 1" if exit else ""
+        for case in map(pathlib.Path, casemap.keys())
+    ]
 
-    open(os.path.join(dir, "runall.sh"), "w").writelines(
-        [line + "\n" for line in content]
-    )
+    open(dir / "runall.sh", "w").writelines([line + "\n" for line in content])
 
     # Generate master postprocessing script
-    if exit:
-        post = common + [
-            "${RUNNER} " + os.path.join(case, "postprocessall.sh || exit 1")
-            for case in casemap.keys()
-        ]
-    else:
-        post = common + [
-            "${RUNNER} " + os.path.join(case, "postprocessall.sh")
-            for case in casemap.keys()
-        ]
+    post = common + [
+        f"${{RUNNER}} { case / 'postprocessall.sh' }" + " || exit 1" if exit else ""
+        for case in map(pathlib.Path, casemap.keys())
+    ]
 
-    open(os.path.join(dir, "postprocessall.sh"), "w").writelines(
-        [line + "\n" for line in post]
-    )
+    open(dir / "postprocessall.sh", "w").writelines([line + "\n" for line in post])
 
     for case, instances in casemap.items():
         # Generate master runner script
         content = common + [
-            "${RUNNER} " + os.path.join(*instance, "run-wrapper.sh")
+            f"${{RUNNER}} {pathlib.Path(*instance, 'run-wrapper.sh')}"
             for instance in instances
         ]
-        open(os.path.join(dir, case, "runall.sh"), "w").writelines(
+        open(dir / case / "runall.sh", "w").writelines(
             [line + "\n" for line in content]
         )
 
         # Generate master postprocessing script
         post = common + [
-            "${RUNNER} " + os.path.join(*instance, "post.sh") for instance in instances
+            f"${{RUNNER}} {pathlib.Path(*instance, 'post.sh')}"
+            for instance in instances
         ]
-        open(os.path.join(dir, case, "postprocessall.sh"), "w").writelines(
+        open(dir / case / "postprocessall.sh", "w").writelines(
             [line + "\n" for line in post]
         )
 
 
-def createRunScript(outdir, path, case):
+def createRunScript(outdir: pathlib.Path, path: pathlib.Path, case):
     amesh = case["A"]["mesh"]["name"]
     aranks = case["A"]["ranks"]
-    ameshLocation = os.path.relpath(
-        os.path.join(outdir, "meshes", amesh, str(aranks), amesh), path
+    ameshLocation = outdir.joinpath("meshes", amesh, str(aranks), amesh).relative_to(
+        path, walk_up=True
     )
 
     # Detect the operating system and set the time command (brew install gnu-time)
@@ -182,8 +154,8 @@ def createRunScript(outdir, path, case):
 
     bmesh = case["B"]["mesh"]["name"]
     branks = case["B"]["ranks"]
-    bmeshLocation = os.path.relpath(
-        os.path.join(outdir, "meshes", bmesh, str(branks), bmesh), path
+    bmeshLocation = outdir.joinpath("meshes", bmesh, str(branks), bmesh).relative_to(
+        path, walk_up=True
     )
     mapped_data_name = case["function"] + "(mapped)"
     output = "--output mapped" if case["computeAccuracy"] else ""
@@ -218,9 +190,7 @@ def createRunScript(outdir, path, case):
         "fi",
         "rm -f running",
     ]
-    open(os.path.join(path, "run.sh"), "w").writelines(
-        [line + "\n" for line in content]
-    )
+    open(path / "run.sh", "w").writelines([line + "\n" for line in content])
 
     # Generate wrapper script for runner
     wrapper = [
@@ -231,9 +201,7 @@ def createRunScript(outdir, path, case):
         "/bin/bash run.sh 2>&1 | tee run.log",
         ")",
     ]
-    open(os.path.join(path, "run-wrapper.sh"), "w").writelines(
-        [line + "\n" for line in wrapper]
-    )
+    open(path / "run-wrapper.sh", "w").writelines([line + "\n" for line in wrapper])
 
     # Generate post processing script
     post_content = [
@@ -252,10 +220,8 @@ def createRunScript(outdir, path, case):
             )
             post_content += [joincmd, diffcmd]
         else:
-            [recoveryFileLocation, tmpPrefix] = os.path.split(
-                os.path.normpath(bmeshLocation)
-            )
-            tmprecoveryFile = recoveryFileLocation + "/{}_recovery.json".format(bmesh)
+            tmprecoveryFile = bmeshLocation.parent / f"{bmesh}_recovery.json"
+
             joincmd = "precice-aste-join --mesh mapped -r {} -o result.vtk".format(
                 tmprecoveryFile
             )
@@ -264,24 +230,21 @@ def createRunScript(outdir, path, case):
             )
             post_content += [joincmd, diffcmd]
 
-    open(os.path.join(path, "post.sh"), "w").writelines(
-        [line + "\n" for line in post_content]
-    )
+    open(path / "post.sh", "w").writelines([line + "\n" for line in post_content])
 
 
-def setupCases(outdir, template, cases, exit):
+def setupCases(outdir: pathlib.Path, template, cases, exit):
     casemap = {}
     for case in cases:
         folders = getCaseFolders(case)
         casemap.setdefault(folders[0], []).append(folders[1:])
-        name = [outdir] + folders
-        path = os.path.join(*name)
-        config = os.path.join(path, "precice-config.xml")
+        path = outdir.joinpath(*folders)
+        config = path / "precice-config.xml"
 
         print(f"Generating {path}")
-        os.makedirs(path, exist_ok=True)
-        with open(config, "w") as config:
-            config.write(generateConfig(template, case))
+        path.mkdir(parents=True, exist_ok=True)
+        with open(config, "w") as cfile:
+            cfile.write(generateConfig(template, case))
         createRunScript(outdir, path, case)
     print(f"Generated {len(cases)} cases")
 
@@ -296,6 +259,7 @@ def parseArguments(args):
         "--outdir",
         default="cases",
         help="Directory to generate the test suite in.",
+        type=pathlib.Path,
     )
     parser.add_argument(
         "-s",
@@ -329,8 +293,8 @@ def main(argv):
     template = args.template.read()
     # Generate the actual cases
     cases = generateCases(setup)
-    outdir = os.path.normpath(args.outdir)
-    if os.path.isdir(outdir):
+    outdir = args.outdir
+    if outdir.is_dir():
         print('Warning: outdir "{}" already exisits.'.format(outdir))
 
     setupCases(outdir, template, cases, args.exit)

--- a/tools/mapping-tester/preparemeshes.py
+++ b/tools/mapping-tester/preparemeshes.py
@@ -4,6 +4,7 @@ import argparse
 import itertools
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 
@@ -15,6 +16,7 @@ def parseArguments(args):
         "--outdir",
         default="cases",
         help="Directory to generate the test suite in.",
+        type=pathlib.Path,
     )
     parser.add_argument(
         "-s",
@@ -30,61 +32,59 @@ def parseArguments(args):
     return parser.parse_args(args)
 
 
-def prepareMainMesh(meshdir, name, file, function, force=False):
-    mainDir = os.path.join(meshdir, name, "1")
-    mainMesh = os.path.join(mainDir, name + ".vtu")
-    print("Preparing Mesh {} in {}".format(name, mainDir))
+def prepareMainMesh(
+    meshdir: pathlib.Path, name, file: pathlib.Path, function, force=False
+):
+    mainDir = meshdir / name / "1"
+    mainMesh = mainDir / f"{name}.vtu"
+    print(f"Preparing Mesh {name} in {mainDir}")
 
-    if os.path.isdir(mainDir):
+    if mainDir.is_dir():
         if force:
             print("  Regenerating the mesh.")
             shutil.rmtree(mainDir)
         else:
             print("  Mesh already exists.")
-
             return
 
-    os.makedirs(mainDir, exist_ok=True)
-    data_name = "{}".format(function)
-    [pathName, tmpfilename] = os.path.split(os.path.normpath(mainMesh))
+    mainDir.mkdir(exist_ok=True, parents=True)
+    data_name = f"{function}"
     subprocess.run(
         [
             "precice-aste-evaluate",
             "--mesh",
-            os.path.expandvars(file),
+            file,
             "--function",
             function,
             "--data",
             data_name,
             "--directory",
-            pathName,
+            mainMesh.parent,
             "-o",
-            tmpfilename,
+            mainMesh.name,
         ]
     )
 
 
-def preparePartMesh(meshdir, name, p, force=False):
+def preparePartMesh(meshdir: pathlib.Path, name, p, force=False):
 
     if p == 1:
         return
 
-    mainMesh = os.path.join(meshdir, name, "1", name + ".vtu")
-    partDir = os.path.join(meshdir, name, str(p))
-    partMesh = os.path.join(partDir, name)
+    mainMesh = meshdir / name / "1" / f"{name}.vtu"
+    partDir = meshdir / name / str(p)
+    partMesh = partDir / name
     print("Preparing Mesh {} with {} paritions in {}".format(name, p, partDir))
 
-    if os.path.isdir(partDir):
+    if partDir.is_dir():
         if force:
             print("  Regenerating the partitioned mesh.")
             shutil.rmtree(partDir)
         else:
             print("  Partitioned mesh already exists.")
-
             return
 
-    os.makedirs(partDir, exist_ok=True)
-    [pathName, tmpfilename] = os.path.split(os.path.normpath(partMesh))
+    partDir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
             "precice-aste-partition",
@@ -95,7 +95,7 @@ def preparePartMesh(meshdir, name, p, force=False):
             "-o",
             partMesh,
             "--directory",
-            pathName,
+            partMesh.parent,
             "-n",
             str(p),
         ]
@@ -105,11 +105,11 @@ def preparePartMesh(meshdir, name, p, force=False):
 def main(argv):
     args = parseArguments(argv[1:])
     setup = json.load(args.setup)
-    outdir = os.path.normpath(args.outdir)
+    outdir: pathlib.Path = args.outdir
 
-    if os.path.isdir(outdir):
-        print('Warning: outdir "{}" already exisits.'.format(outdir))
-    meshdir = os.path.join(outdir, "meshes")
+    if outdir.is_dir():
+        print(f'Warning: outdir "{outdir}" already exisits.')
+    meshdir = outdir / "meshes"
     function = setup["general"]["function"]
 
     partitions = set(
@@ -122,8 +122,9 @@ def main(argv):
             setup["general"]["meshes"]["B"].items(),
         )
     ):
+        file = pathlib.Path(os.path.expandvars(file))
 
-        if not os.path.isfile(os.path.expandvars(file)):
+        if not file.is_file():
             raise Exception(f'\033[91m Unable to open file called "{file}".\033[0m')
         prepareMainMesh(meshdir, name, file, function, args.force)
 


### PR DESCRIPTION
## Main changes of this PR

This PR ports ASTE python script to using `pathlib.Path`.

The creative coding styles of `precice-aste-partition` and `precice-aste-evaluate` make them a challenge to port.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
