### PR TITLE
Use venv in tests

### DIFF
--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -88,13 +88,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: install example dependencies
         run: |
-          python3 -m pip install -r requirements.txt
+          python3 -m venv --system-site-packages venv
+          venv/bin/pip install -r requirements.txt
       - name: prepare build directory
         run: |
           mkdir build
       - name: build aste
         working-directory: build
         run: |
+          . ../venv/bin/activate
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} ..
           cmake --build .
       - name: Adjust user rights
@@ -102,4 +104,4 @@ jobs:
       - name: run test
         working-directory: build
         run: |
-          su -c "ctest" precice
+          su -c ". ../venv/bin/activate && ctest" precice

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -62,7 +62,7 @@ jobs:
         CXX: ["clang++", "g++"]
         TYPE: ["Debug", "Release"]
     env:
-      CXX: ${{ matrix.CXX }}
+      CXX: ${{ matrix.CXX }}Another effective strategy is to install your virtual environment as follows:
       CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
       CTEST_OUTPUT_ON_FAILURE: "Yes"
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -88,7 +88,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: install example dependencies
         run: |
+          echo 1
+          pip list
           python3 -m venv --system-site-packages venv
+          echo 2
+          venv/bin/pip list
+
+          export PYTHONPATH="${PYTHONPATH}:/usr/local/lib/*/site-packages/"
+          echo 3
+          venv/bin/pip list
+
           venv/bin/pip install -r requirements.txt
       - name: prepare build directory
         run: |

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -62,7 +62,7 @@ jobs:
         CXX: ["clang++", "g++"]
         TYPE: ["Debug", "Release"]
     env:
-      CXX: ${{ matrix.CXX }}Another effective strategy is to install your virtual environment as follows:
+      CXX: ${{ matrix.CXX }}
       CXX_FLAGS: "-Werror -Wall -Wextra -Wno-unused-parameter"
       CTEST_OUTPUT_ON_FAILURE: "Yes"
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/aste_ci.yml
+++ b/.github/workflows/aste_ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: setup system
         run: |
           apt-get -y update && apt-get -y upgrade
-          apt-get install -qq -y python3-pip python3-jinja2 python3-scipy python3-sympy libmetis-dev time clang
+          apt-get install -qq -y python3-pip python3-venv python3-jinja2 python3-scipy python3-sympy libmetis-dev time clang
       - uses: actions/checkout@v4
       - name: install example dependencies
         run: |


### PR DESCRIPTION
## Main changes of this PR

This PR changes the CI to use python `venv`, which is now required as the `precice/precice:nightly` is based on Ubuntu 24.04.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
