### PR TITLE
Fix empty string in generation script

### DIFF
--- a/changelog-entries/236.md
+++ b/changelog-entries/236.md
@@ -1,0 +1,1 @@
+- Fixed a bug in generate.py leading to empty strings in the master run scripts.

--- a/tools/mapping-tester/generate.py
+++ b/tools/mapping-tester/generate.py
@@ -99,7 +99,7 @@ def createMasterRunScripts(casemap, dir: pathlib.Path, exit):
 
     # Generate master runner script
     content = common + [
-        f"${{RUNNER}} { case / 'runall.sh' }" + " || exit 1" if exit else ""
+        f"${{RUNNER}} {case / 'runall.sh'}{' || exit 1' if exit else ''}"
         for case in map(pathlib.Path, casemap.keys())
     ]
 
@@ -107,7 +107,7 @@ def createMasterRunScripts(casemap, dir: pathlib.Path, exit):
 
     # Generate master postprocessing script
     post = common + [
-        f"${{RUNNER}} { case / 'postprocessall.sh' }" + " || exit 1" if exit else ""
+        f"${{RUNNER}} {case / 'postprocessall.sh'}{' || exit 1' if exit else ''}"
         for case in map(pathlib.Path, casemap.keys())
     ]
 


### PR DESCRIPTION
## Main changes of this PR

Here we go again. Fixes an empty string in the generation of the master scripts.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
