### PR TITLE
Fix gathering of timings

### DIFF
--- a/changelog-entries/238.md
+++ b/changelog-entries/238.md
@@ -1,0 +1,1 @@
+- Fixed a bug in the gathering script of the mapping tester, which stopped delivering the correct timings.

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -68,20 +68,28 @@ def timingStats(dir: pathlib.Path):
             .select("event", "duration")
         )
         return {
-            "globalTime": df.select(pl.col("event") == "_GLOBAL").max().item(),
-            "initializeTime": df.select(pl.col("event") == "initialize").max().item(),
-            "computeMappingTime": df.select(
+            "globalTime": df.filter(pl.col("event") == "_GLOBAL")
+            .select("duration")
+            .max()
+            .item(),
+            "initializeTime": df.filter(pl.col("event") == "initialize")
+            .select("duration")
+            .max()
+            .item(),
+            "computeMappingTime": df.filter(
                 pl.col("event").str.contains(
                     "^initialize/map..*.computeMapping.FromA-MeshToB-Mesh$"
                 )
             )
+            .select("duration")
             .max()
             .item(),
-            "mapDataTime": df.select(
+            "mapDataTime": df.filter(
                 pl.col("event").str.contains(
                     "^advance/map..*.mapData.FromA-MeshToB-Mesh$"
                 )
             )
+            .select("duration")
             .max()
             .item(),
         }


### PR DESCRIPTION
## Main changes of this PR

Bug introduced in #235 

#235 leads currently only to a bit mask as timing results, not the actual timing.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
