### PR TITLE
Port to using precice-profiling

### DIFF
--- a/changelog-entries/245.md
+++ b/changelog-entries/245.md
@@ -1,0 +1,2 @@
+- Migrated from using the preCICE-provided `precice-profiling` script to using the precice-profiling PyPi package.
+- Fixed missing `return_dtype` in polars `map_batches`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ jinja2
 matplotlib
 numpy
 polars
+precice-profiling >= 2.0.2
 scipy
 sympy>=1.9

--- a/tools/mapping-tester/aggregate.py
+++ b/tools/mapping-tester/aggregate.py
@@ -50,10 +50,14 @@ def run(file: pathlib.Path, kind: str, exclude: bool, dest: pathlib.Path):
     func = {
         "median": lambda c: pl.col(c).median(),
         "mean": lambda c: (
-            pl.col(c).map_batches(trim).mean() if exclude else pl.col(c).mean()
+            pl.col(c).map_batches(trim, return_dtype=pl.self_dtype()).mean()
+            if exclude
+            else pl.col(c).mean()
         ),
         "variance": lambda c: (
-            pl.col(c).map_batches(trim).var() if exclude else pl.col(c).var()
+            pl.col(c).map_batches(trim, return_dtype=pl.self_dtype()).var()
+            if exclude
+            else pl.col(c).var()
         ),
     }[kind]
 

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -39,11 +39,11 @@ def run_checked(args):
 
 def timingStats(dir: pathlib.Path):
     assert dir.is_dir()
-    assert (
-        os.system("command -v precice-profiling > /dev/null") == 0
-    ), 'Could not find the profiling tool "precice-profiling", which is part of the preCICE installation.'
+    for cmd in ["merge", "export"]:
+        assert (
+            os.system(f"command -v precice-profiling-{cmd} > /dev/null") == 0
+        ), 'Could not find the profiling tool "precice-profiling-{cmd}", which is part of the precice-profiling PiPy package.'
     event_dir = dir / "precice-profiling"
-    json_file = dir / "profiling.json"
     timings_file = dir / "timings.csv"
 
     if not event_dir.is_dir():
@@ -51,14 +51,16 @@ def timingStats(dir: pathlib.Path):
 
     try:
         subprocess.run(
-            ["precice-profiling", "merge", "--output", json_file, event_dir],
+            ["precice-profiling-merge", event_dir],
             check=True,
             capture_output=True,
+            cwd=dir,
         )
         subprocess.run(
-            ["precice-profiling", "export", "--output", timings_file, json_file],
+            ["precice-profiling-export", "--output", timings_file],
             check=True,
             capture_output=True,
+            cwd=dir,
         )
         import polars as pl
 

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -51,13 +51,13 @@ def timingStats(dir: pathlib.Path):
 
     try:
         subprocess.run(
-            ["precice-profiling-merge", event_dir],
+            ["precice-profiling-merge", event_dir.absolute()],
             check=True,
             capture_output=True,
             cwd=dir,
         )
         subprocess.run(
-            ["precice-profiling-export", "--output", timings_file],
+            ["precice-profiling-export", "--output", timings_file.absolute()],
             check=True,
             capture_output=True,
             cwd=dir,


### PR DESCRIPTION
## Main changes of this PR

This PR changes ASTE to using the precice-profiling package.
It also fixes and unifies the run scripts of the examples and fixes the CTest fixture logic.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
