### PR TITLE
Cleanup and unify example scripts

### DIFF
--- a/examples/clean-all.sh
+++ b/examples/clean-all.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e -u
 
+cd "$(dirname "$0")"
+
 echo "- Cleaning up all test examples..."
 
 find . -maxdepth 2 -mindepth 2 -name clean.sh -execdir sh -c './clean.sh' \;

--- a/examples/lci_2d/clean.sh
+++ b/examples/lci_2d/clean.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 rm -f -r precice-run
 rm -f -r precice-profiling
 rm -f profiling.json

--- a/examples/lci_2d/run.sh
+++ b/examples/lci_2d/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 # Calculate franke function on fine mesh
 precice-aste-evaluate -m ./fine_mesh.vtk -f "franke2d(xy)" -d "Franke Function" -o "fine_mesh_lci.vtk"
 

--- a/examples/lci_3d/clean.sh
+++ b/examples/lci_3d/clean.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 rm -f -r precice-run
 rm -f -r precice-profiling
 rm -f profiling.json

--- a/examples/lci_3d/run.sh
+++ b/examples/lci_3d/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 # Calculate franke function on fine mesh
 precice-aste-evaluate -m ./fine_mesh.vtk -f "franke3d" -d "Franke Function" -o "fine_mesh_lci.vtk"
 

--- a/examples/mapping_tester/clean.sh
+++ b/examples/mapping_tester/clean.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")"
+
 rm -f test-statistics.csv
 rm -fr ./case/

--- a/examples/mapping_tester/run.sh
+++ b/examples/mapping_tester/run.sh
@@ -1,36 +1,29 @@
 #!/usr/bin/env bash
 set -e -x
 
-# Get the test location
-TEST_LOCATION="$(pwd)"
-export TEST_LOCATION
+cd "$(dirname "$0")"
 
 # The mapping-tester location
-MAPPING_TESTER="${TEST_LOCATION}"/../../tools/mapping-tester/
+MAPPING_TESTER=../../tools/mapping-tester
 
 # The case directory
-TEST_CASE_LOCATION="${TEST_LOCATION}"/case
+TEST_CASE_LOCATION=case
 
 # Generate the run scripts
-python3 "${MAPPING_TESTER}"/generate.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}"/config-template.xml --exit
+python3 "${MAPPING_TESTER}/generate.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}/config-template.xml" --exit
 
 # Prepare the meshes
-python3 "${MAPPING_TESTER}"/preparemeshes.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
+python3 "${MAPPING_TESTER}/preparemeshes.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
 
 export ASTE_A_MPIARGS=""
 export ASTE_B_MPIARGS=""
 
 # Run the actual cases
-cd "${TEST_CASE_LOCATION}" && bash ./runall.sh
-
-# Postprocess the test cases
-bash ./postprocessall.sh
-
-cd "${TEST_LOCATION}"
+( cd "${TEST_CASE_LOCATION}" && bash ./runall.sh && bash ./postprocessall.sh )
 
 # Gather the generated statistics
-python3 "${MAPPING_TESTER}"/gatherstats.py --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
+python3 "${MAPPING_TESTER}/gatherstats.py" --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/compare.py reference-statistics.csv test-statistics.csv
+python3 "${MAPPING_TESTER}/compare.py" reference-statistics.csv test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/plotconv.py -f test-statistics.csv
+python3 "${MAPPING_TESTER}/plotconv.py" -f test-statistics.csv

--- a/examples/mapping_tester/setup-test.json
+++ b/examples/mapping_tester/setup-test.json
@@ -12,10 +12,10 @@
     "synchronize": false,
     "meshes": {
       "A": {
-        "coarse_mesh": "${TEST_LOCATION}/coarse_mesh.vtk"
+        "coarse_mesh": "coarse_mesh.vtk"
       },
       "B": {
-        "fine_mesh": "${TEST_LOCATION}/fine_mesh.vtk"
+        "fine_mesh": "fine_mesh.vtk"
       }
     }
   },

--- a/examples/mapping_tester_conv/clean.sh
+++ b/examples/mapping_tester_conv/clean.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")"
+
 rm -f test-statistics.csv *.pdf
 rm -fr ./case/

--- a/examples/mapping_tester_conv/run.sh
+++ b/examples/mapping_tester_conv/run.sh
@@ -1,35 +1,28 @@
 #!/usr/bin/env bash
 set -e -x
 
-# Get the test location
-TEST_LOCATION="$(pwd)"
-export TEST_LOCATION
+cd "$(dirname "$0")"
 
 # The mapping-tester location
-MAPPING_TESTER="${TEST_LOCATION}"/../../tools/mapping-tester/
+MAPPING_TESTER=../../tools/mapping-tester
 
 # The case directory
-TEST_CASE_LOCATION="${TEST_LOCATION}"/case
+TEST_CASE_LOCATION=case
 
 # Generate the run scripts
-python3 "${MAPPING_TESTER}"/generate.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}"/config-template.xml --exit
+python3 "${MAPPING_TESTER}/generate.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}/config-template.xml" --exit
 # Prepare the meshes
-python3 "${MAPPING_TESTER}"/preparemeshes.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
+python3 "${MAPPING_TESTER}/preparemeshes.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
 
 export ASTE_A_MPIARGS=""
 export ASTE_B_MPIARGS=""
 
 # Run the actual cases
-cd "${TEST_CASE_LOCATION}" && bash ./runall.sh
-
-# Postprocess the test cases
-bash ./postprocessall.sh
-
-cd "${TEST_LOCATION}"
+( cd "${TEST_CASE_LOCATION}" && bash ./runall.sh && bash ./postprocessall.sh )
 
 # Gather the generated statistics
-python3 "${MAPPING_TESTER}"/gatherstats.py --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
+python3 "${MAPPING_TESTER}/gatherstats.py" --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/plotconv.py -f test-statistics.csv
+python3 "${MAPPING_TESTER}/plotconv.py" -f test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/compare.py reference-statistics.csv test-statistics.csv
+python3 "${MAPPING_TESTER}/compare.py" reference-statistics.csv test-statistics.csv

--- a/examples/mapping_tester_conv/setup-test.json
+++ b/examples/mapping_tester_conv/setup-test.json
@@ -12,14 +12,14 @@
     "synchronize": false,
     "meshes": {
       "A": {
-        "0.1": "${TEST_LOCATION}/meshes/0.1.vtk",
-        "0.0775": "${TEST_LOCATION}/meshes/0.0775.vtk",
-        "0.055": "${TEST_LOCATION}/meshes/0.055.vtk",
-        "0.0325": "${TEST_LOCATION}/meshes/0.0325.vtk",
-        "0.01": "${TEST_LOCATION}/meshes/0.01.vtk"
+        "0.1": "meshes/0.1.vtk",
+        "0.0775": "meshes/0.0775.vtk",
+        "0.055": "meshes/0.055.vtk",
+        "0.0325": "meshes/0.0325.vtk",
+        "0.01": "meshes/0.01.vtk"
       },
       "B": {
-        "0.06": "${TEST_LOCATION}/meshes/0.06.vtk"
+        "0.06": "meshes/0.06.vtk"
       }
     }
   },

--- a/examples/mapping_tester_runtime/clean.sh
+++ b/examples/mapping_tester_runtime/clean.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "$0")"
+
 rm -f test-statistics*.csv
 rm -fr ./case/

--- a/examples/mapping_tester_runtime/run.sh
+++ b/examples/mapping_tester_runtime/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -e -x
 
-cd "$(basedir "$0")"
+cd "$(dirname "$0")"
 
 # The mapping-tester location
-export MAPPING_TESTER=../../tools/mapping-tester
+MAPPING_TESTER=../../tools/mapping-tester
 
 # Generate the run scripts
-python3 "${MAPPING_TESTER}/generate.py" --template "${MAPPING_TESTER}"/config-template.xml --exit
+python3 "${MAPPING_TESTER}/generate.py" --template "${MAPPING_TESTER}/config-template.xml" --exit
 
 # Prepare the meshes
 python3 "${MAPPING_TESTER}/preparemeshes.py" --force

--- a/examples/mapping_tester_serial/clean.sh
+++ b/examples/mapping_tester_serial/clean.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")"
+
 rm -f test-statistics.csv
 rm -fr ./case/

--- a/examples/mapping_tester_serial/run.sh
+++ b/examples/mapping_tester_serial/run.sh
@@ -1,36 +1,29 @@
 #!/usr/bin/env bash
 set -e -x
 
-# Get the test location
-TEST_LOCATION="$(pwd)"
-export TEST_LOCATION
+cd "$(dirname "$0")"
 
 # The mapping-tester location
-MAPPING_TESTER="${TEST_LOCATION}"/../../tools/mapping-tester/
+MAPPING_TESTER=../../tools/mapping-tester
 
 # The case directory
-TEST_CASE_LOCATION="${TEST_LOCATION}"/case
+TEST_CASE_LOCATION=case
 
 # Generate the run scripts
-python3 "${MAPPING_TESTER}"/generate.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}"/config-template.xml --exit
+python3 "${MAPPING_TESTER}/generate.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --template "${MAPPING_TESTER}/config-template.xml" --exit
 
 # Prepare the meshes
-python3 "${MAPPING_TESTER}"/preparemeshes.py --setup "${TEST_LOCATION}"/setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
+python3 "${MAPPING_TESTER}/preparemeshes.py" --setup setup-test.json --outdir "${TEST_CASE_LOCATION}" --force
 
 export ASTE_A_MPIARGS=""
 export ASTE_B_MPIARGS=""
 
 # Run the actual cases
-cd "${TEST_CASE_LOCATION}" && bash ./runall.sh
-
-# Postprocess the test cases
-bash ./postprocessall.sh
-
-cd "${TEST_LOCATION}"
+( cd "${TEST_CASE_LOCATION}" && bash ./runall.sh && bash ./postprocessall.sh )
 
 # Gather the generated statistics
-python3 "${MAPPING_TESTER}"/gatherstats.py --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
+python3 "${MAPPING_TESTER}/gatherstats.py" --outdir "${TEST_CASE_LOCATION}" --file test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/compare.py reference-statistics.csv test-statistics.csv
+python3 "${MAPPING_TESTER}/compare.py" reference-statistics.csv test-statistics.csv
 
-python3 "${MAPPING_TESTER}"/plotconv.py -f test-statistics.csv
+python3 "${MAPPING_TESTER}/plotconv.py" -f test-statistics.csv

--- a/examples/mapping_tester_serial/setup-test.json
+++ b/examples/mapping_tester_serial/setup-test.json
@@ -12,10 +12,10 @@
     "synchronize": false,
     "meshes": {
       "A": {
-        "coarse_mesh": "${TEST_LOCATION}/coarse_mesh.vtk"
+        "coarse_mesh": "coarse_mesh.vtk"
       },
       "B": {
-        "fine_mesh": "${TEST_LOCATION}/fine_mesh.vtk"
+        "fine_mesh": "fine_mesh.vtk"
       }
     }
   },

--- a/examples/nn/clean.sh
+++ b/examples/nn/clean.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 rm -f -r precice-run
 rm -f -r precice-profiling
 rm -f profiling.json

--- a/examples/nn/run.sh
+++ b/examples/nn/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 # Calculate franke function on fine mesh
 precice-aste-evaluate -m ../fine_mesh.vtk -f "franke3d" -d "Franke Function" -o "fine_mesh_nn.vtk"
 

--- a/examples/nng_scalar/clean.sh
+++ b/examples/nng_scalar/clean.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 rm -f -r precice-run
 rm -f -r precice-profiling
 rm -f profiling.json

--- a/examples/nng_scalar/run.sh
+++ b/examples/nng_scalar/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 # Calculate distance from origin on fine mesh
 precice-aste-evaluate -m ../fine_mesh.vtk -f "sqrt(x^2+y^2+z^2)" -d "Distance" -o "fine_mesh_nng.vtk" --gradient
 

--- a/examples/nng_vector/clean.sh
+++ b/examples/nng_vector/clean.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 rm -f -r precice-run
 rm -f -r precice-profiling
 rm -f profiling.json

--- a/examples/nng_vector/run.sh
+++ b/examples/nng_vector/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -x
 
+cd "$(dirname "$0")"
+
 # Calculate distance from origin on fine mesh
 precice-aste-evaluate -m ../fine_mesh.vtk -f "sin(x)*iHat+cos(y)*jHat+z^2*kHat" -d "MyFunction" -o "fine_mesh_nng.vtk" --gradient
 

--- a/examples/replay_mode/clean.sh
+++ b/examples/replay_mode/clean.sh
@@ -2,6 +2,8 @@
 
 set -e -u
 
+cd "$(dirname "$0")"
+
 # Remove log and json records
 rm -f precice*.json
 rm -f precice*.log

--- a/examples/replay_mode/run.sh
+++ b/examples/replay_mode/run.sh
@@ -2,6 +2,7 @@
 
 set -e -u
 
+cd "$(dirname "$0")"
 
 # Run Fluid Side
 precice-aste-run --aste-config aste-config-fluid.json &


### PR DESCRIPTION
## Main changes of this PR

This PR unifies examples run and cleanup scripts.
They now all consistently `cd` into the script directory and work relative from there.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
