### PR TITLE
Fix test fixtures in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,13 +124,11 @@ add_test(NAME read_write_test  COMMAND test-precice-aste WORKING_DIRECTORY "${CM
 set(_examples lci_2d lci_3d nn nng_scalar nng_vector mapping_tester mapping_tester_serial mapping_tester_runtime mapping_tester_conv replay_mode)
 
 foreach(example IN LISTS _examples)
-  add_test(NAME aste.example.${example}.setup
-    COMMAND clean.sh
-    FIXTURE_SETUP ${example})
+  add_test(NAME aste.example.${example}.setup COMMAND clean.sh)
+  set_tests_properties(aste.example.${example}.setup PROPERTIES FIXTURE_SETUP ${example})
 
-  add_test(NAME aste.example.${example}
-    COMMAND run.sh
-    FIXTURE_REQUIRES ${example})
+  add_test(NAME aste.example.${example} COMMAND run.sh)
+  set_tests_properties(aste.example.${example} PROPERTIES FIXTURE_REQUIRED ${example})
 
   set_tests_properties(aste.example.${example} aste.example.${example}.setup
     PROPERTIES


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the test fixtures in CMake.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).

<!-- add more questions/tasks if necessary -->
