### PR TITLE
mapping-tester fixes for errors caused by conservative mappings

### DIFF
--- a/tools/mapping-tester/config-template.xml
+++ b/tools/mapping-tester/config-template.xml
@@ -66,7 +66,7 @@
       {% if mapping.constraint == "consistent" %}
       <exchange data="Data" mesh="A-Mesh" from="A" to="B" />
       {% else %}
-      <exchange data="Data" mesh="B-Mesh" from="B" to="A" />
+      <exchange data="Data" mesh="B-Mesh" from="A" to="B" />
       {% endif %}
     </coupling-scheme:parallel-explicit>
 

--- a/tools/mapping-tester/gatherstats.py
+++ b/tools/mapping-tester/gatherstats.py
@@ -37,7 +37,7 @@ def run_checked(args):
     r.check_returncode()
 
 
-def timingStats(dir: pathlib.Path):
+def timingStats(dir: pathlib.Path, constraint: str):
     assert dir.is_dir()
     for cmd in ["merge", "export"]:
         assert (
@@ -64,9 +64,11 @@ def timingStats(dir: pathlib.Path):
         )
         import polars as pl
 
+        participant = "A" if constraint == "conservative" else "B"
+
         df = (
             pl.read_csv(timings_file)
-            .filter(pl.col("participant") == "B")
+            .filter(pl.col("participant") == participant)
             .select("event", "duration")
         )
         return {
@@ -143,7 +145,7 @@ def gatherCaseStats(casedir: pathlib.Path):
         "ranks A": ranksA,
         "ranks B": ranksB,
     }
-    stats.update(timingStats(casedir))
+    stats.update(timingStats(casedir, constraint))
     stats.update(memoryStats(casedir))
     stats.update(mappingStats(casedir))
     return stats


### PR DESCRIPTION

## Main changes of this PR

This PR aims to fix some small problems in the mapping-tester concerning conservative mappings.
- incorrect configuration causing crash
- incorrect reading of timing data causing null entries

## Description of the errors fixed by this PR

Executing a conservative mapping using the current `config-template.xml` causes the following error:

```
---[preCICE:B:0] (cplscheme::CouplingSchemeConfiguration in checkSubstepExchangeWaveformDegree) WARNING : You defined <exchange data="Data" ... to="A" /> in the <coupling-scheme:... />, but <participant name="A"> has no corresponding <read-data name="Data" ... />. Usually this means that there is an error in your configuration.---[preCICE:A:0] (cplscheme::CouplingSchemeConfiguration in checkSubstepExchangeWaveformDegree) WARNING : You defined <exchange data="Data" ... to="A" /> in the <coupling-scheme:... />, but <participant name="A"> has no corresponding <read-data name="Data" ... />. Usually this means that there is an error in your configuration.

---[preCICE:B:0] (cplscheme::BaseCouplingScheme in checkCouplingDataAvailable) ERROR : Data Data on mesh B-Mesh doesn't contain any samples while initializing a coupling scheme of participant B. There are two common configuration issues that may cause this. Either, make sure participant B specifies data Data to be written using tag <write-data mesh="B-Mesh" data="Data"/>. Or ensure participant B defines a mapping to mesh B-Mesh from a mesh using data Data.
terminate called after throwing an instance of 'precice::Error'
```
This is caused by a small error in the configuration of the coupling scheme.

Using the `gatherstats.py` script with a fix for the previous problem applied as follows:
```
python3 "${MAPPING_TESTER}"/gatherstats.py --outdir "${RUN_LOCATION}" --file statistics.csv
```
causes the entries for `mapDataTime` and `computeMappingTime` to be empty:

```
┌────────────┬────────────────┬─────────────┬────────────────────┐
│ globalTime ┆ initializeTime ┆ mapDataTime ┆ computeMappingTime │
│ ---        ┆ ---            ┆ ---         ┆ ---                │
│ i64        ┆ i64            ┆ str         ┆ str                │
╞════════════╪════════════════╪═════════════╪════════════════════╡
│ 42064406   ┆ 6942           ┆ null        ┆ null               │
└────────────┴────────────────┴─────────────┴────────────────────┘
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [ ] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).
