### PR TITLE
Removes the long deprecated boost system library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package (Threads REQUIRED)
 
 find_package(precice 3.0 REQUIRED)
 
-find_package(Boost 1.71.0 CONFIG REQUIRED COMPONENTS log log_setup system program_options unit_test_framework)
+find_package(Boost 1.71.0 CONFIG REQUIRED COMPONENTS log log_setup program_options unit_test_framework)
 
 # Initial attempt to find VTK without specifying components (only supported for VTK9)
 find_package(VTK QUIET)
@@ -63,7 +63,6 @@ target_link_libraries(precice-aste-run
   Boost::log
   Boost::log_setup
   Boost::program_options
-  Boost::system
   Boost::thread
   Boost::unit_test_framework
   MPI::MPI_CXX
@@ -86,7 +85,6 @@ target_link_libraries(test-precice-aste
   Boost::log
   Boost::log_setup
   Boost::program_options
-  Boost::system
   Boost::thread
   Boost::unit_test_framework
   MPI::MPI_CXX

--- a/changelog-entries/254.md
+++ b/changelog-entries/254.md
@@ -1,0 +1,1 @@
+- Removed Boost.system as a library dependency as it has been changed to header-only in Boost 1.89.0.


### PR DESCRIPTION
## Main changes of this PR

The library is header only and the stub was now removed in Boost 1.89.0.

https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) and used `pre-commit run --all` to apply all available hooks.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I updated the documentation in `docs/README.md`.
* [x] I added a changelog entry in `./changelog-entries/` (create if necessary).
* [ ] I updated potential breaking changes in the tutorial [`precice/tutorials/aste-turbine`](https://github.com/precice/tutorials/tree/develop/aste-turbine).
